### PR TITLE
Add helper script to setup new prototypes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ yarn-debug.log*
 yarn-error.log*
 lerna-debug.log*
 .pnpm-debug.log*
+.DS_Store
 
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+
+
+.PHONY: prototype
+prototype:
+ifndef NAME
+    $(error Need a value for NAME, e.g., make prototype NAME=value)
+endif
+	@mkdir -p prototypes/${NAME}
+	@cd prototypes/${NAME} && npx govuk-prototype-kit@latest create
+	@echo "\
+	You should now change the service name in prototypes/${NAME}/app/config.json\n\
+	and edit the homepage at prototypes/${NAME}/app/views/index.html\n\
+\n\
+	You can run the prototype with:\n\
+\n\
+	    cd prototypes/${NAME}\n\
+	    npm run dev\n\
+	"

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ ifndef NAME
     $(error Need a value for NAME, e.g., make prototype NAME=value)
 endif
 	@mkdir -p prototypes/${NAME}
-	@cd prototypes/${NAME} && npx govuk-prototype-kit@latest create
+	@cd prototypes/${NAME} && npx govuk-prototype-kit@latest create && npm install ../../lib/importer
 	@echo "\
 	You should now change the service name in prototypes/${NAME}/app/config.json\n\
 	and edit the homepage at prototypes/${NAME}/app/views/index.html\n\

--- a/lib/importer/index.js
+++ b/lib/importer/index.js
@@ -1,0 +1,3 @@
+exports.announce = function () {
+  console.log("This is a message from the fancy importer package");
+};

--- a/lib/importer/package-lock.json
+++ b/lib/importer/package-lock.json
@@ -1,0 +1,43 @@
+{
+  "name": "importer",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "importer",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "node-xlsx": "^0.24.0"
+      }
+    },
+    "node_modules/node-xlsx": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/node-xlsx/-/node-xlsx-0.24.0.tgz",
+      "integrity": "sha512-1olwK48XK9nXZsyH/FCltvGrQYvXXZuxVitxXXv2GIuRm51aBi1+5KwR4rWM4KeO61sFU+00913WLZTD+AcXEg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz"
+      },
+      "bin": {
+        "node-xlsx": "dist/bin/cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/xlsx": {
+      "version": "0.20.2",
+      "resolved": "https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz",
+      "integrity": "sha512-+nKZ39+nvK7Qq6i0PvWWRA4j/EkfWOtkP/YhMtupm+lJIiHxUrgTr1CcKv1nBk1rHtkRRQ3O2+Ih/q/sA+FXZA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    }
+  }
+}

--- a/lib/importer/package.json
+++ b/lib/importer/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "importer",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "description": ""
+}

--- a/lib/importer/package.json
+++ b/lib/importer/package.json
@@ -7,5 +7,8 @@
   },
   "author": "",
   "license": "ISC",
-  "description": ""
+  "description": "",
+  "dependencies": {
+    "node-xlsx": "^0.24.0"
+  }
 }


### PR DESCRIPTION
Using `make prototype NAME=something` will create a new prototype in prototypes/ and tell you what the next steps are. In addition to creating the prototype, it imports the local 'importer' package (eventual name TBD) so that any exported functions can be used in the prototype kit.  The 'importer' dependency will be reloaded by the prototype kit if any changes are made to it. 
