### PR TITLE
Ensure lib importer dependencies are installed for new prototype

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ prototype:
 ifndef NAME
     $(error Need a value for NAME, e.g., make prototype NAME=value)
 endif
+	@cd lib/importer && npm install
 	@mkdir -p prototypes/${NAME}
 	@cd prototypes/${NAME} && npx govuk-prototype-kit@latest create && npm install ../../lib/importer
 	@echo "\


### PR DESCRIPTION
When creating a prototype, we reference the local importer and as a result it will use its own local node_modules, if it is not up to date then this will introduce problems in the prototype.

Now we do an `npm i` in lib/importer to make sure its dependencies are up to date.

Fixes #8