### PR TITLE
Wrap key functionality in nunjucks macros

### DIFF
--- a/lib/importer/govuk-prototype-kit.config.json
+++ b/lib/importer/govuk-prototype-kit.config.json
@@ -28,5 +28,22 @@
   ],
   "assets": [
     "/assets"
+  ],
+  "nunjucksPaths": [
+    "/nunjucks/"
+  ],
+  "nunjucksMacros": [
+    {
+      "macroName": "importerSheetSelector",
+      "importFrom": "importer/macros/sheet_selector.njk"
+    },
+    {
+      "macroName": "importerFieldMapper",
+      "importFrom": "importer/macros/field_mapper.njk"
+    },
+    {
+      "macroName": "importerTableView",
+      "importFrom": "importer/macros/table_view.njk"
+    }
   ]
 }

--- a/lib/importer/nunjucks/importer/macros/field_mapper.njk
+++ b/lib/importer/nunjucks/importer/macros/field_mapper.njk
@@ -1,0 +1,17 @@
+
+{% macro importerFieldMapper(headings, fields) %}
+    {% for h in headings %}
+        <div class="govuk-grid-column-two-thirds" style="margin-bottom: 1em;">
+            <label class="govuk-label govuk-label--s" style="float:left" for="{{h.name}}">
+                {{ h.name }}
+            </label>
+
+            <select class="govuk-select" style="float: right;" name="{{h.index}}">
+                <option name=""></option>
+                {% for field in fields %}
+                <option value="{{field}}">{{field}}</option>
+                {% endfor %}
+            </select>
+        </div>
+    {% endfor %}
+{% endmacro %}

--- a/lib/importer/nunjucks/importer/macros/sheet_selector.njk
+++ b/lib/importer/nunjucks/importer/macros/sheet_selector.njk
@@ -1,9 +1,9 @@
 
-{% macro importerSheetSelector(sheets) %}
+{% macro importerSheetSelector(sheets, selectedSheet) %}
   {% for sheet in sheets %}
   <div class="govuk-radios__item">
     <input class="govuk-radios__input" id="{{sheet}}" name="sheet" type="radio" value="{{sheet}}" {% if
-      selected==sheet %}checked{% endif %}>
+      selectedSheet==sheet %}checked{% endif %}>
     <label class="govuk-label govuk-radios__label" for="{{sheet}}">
       {{sheet}}
     </label>

--- a/lib/importer/nunjucks/importer/macros/sheet_selector.njk
+++ b/lib/importer/nunjucks/importer/macros/sheet_selector.njk
@@ -1,0 +1,12 @@
+
+{% macro importerSheetSelector(sheets) %}
+  {% for sheet in sheets %}
+  <div class="govuk-radios__item">
+    <input class="govuk-radios__input" id="{{sheet}}" name="sheet" type="radio" value="{{sheet}}" {% if
+      selected==sheet %}checked{% endif %}>
+    <label class="govuk-label govuk-radios__label" for="{{sheet}}">
+      {{sheet}}
+    </label>
+  </div>
+  {% endfor %}
+{% endmacro %}

--- a/lib/importer/nunjucks/importer/macros/table_view.njk
+++ b/lib/importer/nunjucks/importer/macros/table_view.njk
@@ -1,0 +1,23 @@
+
+
+{% macro importerTableView(headings, rows) %}
+<table class="selectable govuk-body">
+    <thead>
+        <tr>
+        {% for h in headings %}
+            <th>{{h}}</th>
+        {% endfor %}
+        </tr>
+    </thead>
+    <tbody>
+        {% for row in rows %}
+        <tr>
+            {% for cell in row %}
+            <td>{{cell}}</td>
+            {% endfor %}
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+
+{% endmacro %}

--- a/lib/importer/templates/mapping.html
+++ b/lib/importer/templates/mapping.html
@@ -5,20 +5,7 @@
 {{ govukBackLink({ text: "Back", href: "javascript:window.history.back()" }) }}
 {% endblock %}
 
-{% macro mapping_select(h, fields=[]) %}
-<div class="govuk-grid-column-two-thirds" style="margin-bottom: 1em;">
-    <label class="govuk-label govuk-label--s" style="float:left" for="{{h.name}}">
-        {{ h.name }}
-    </label>
-
-    <select class="govuk-select" style="float: right;" name="{{h.index}}">
-        <option name=""></option>
-        {% for field in fields %}
-        <option value="{{field}}">{{field}}</option>
-        {% endfor %}
-    </select>
-</div>
-{% endmacro %}
+{% from "importer/macros/field_mapper.njk" import importerFieldMapper %}
 
 {% block content %}
 <div class="govuk-grid-row">
@@ -28,9 +15,8 @@
         <h2 class="govuk-heading-m">{{sheet}}</h2>
 
         <form action="." method="post">
-            {% for heading in headings %}
-            {{ mapping_select(heading, fields) }}
-            {% endfor %}
+
+            {{ importerFieldMapper(headings, fields) }}
 
             <div class="govuk-grid-column-two-thirds">
                 <div class="govuk-button-group">

--- a/lib/importer/templates/review.html
+++ b/lib/importer/templates/review.html
@@ -10,6 +10,8 @@
 <script type="text/javascript" src="/plugin-assets/importer/assets/js/keys.js"></script>
 {% endblock %}
 
+{% from "importer/macros/table_view.njk" import importerTableView %}
+
 
 {% block pageTitle %} – {{ serviceName }} – GOV.UK Prototype Kit {% endblock %}
 {% block beforeContent %}
@@ -21,25 +23,7 @@
     <div class="govuk-grid-column-two-thirds">
         <h1 class="govuk-heading-l">Review your data</h1>
 
-
-        <table class="selectable govuk-body">
-            <thead>
-                {% for h in headers %}
-                <th>{{h}}</th>
-                {% endfor %}
-            </thead>
-            <tbody>
-                {% for row in rows %}
-                <tr>
-                    {% for cell in row %}
-                    <td>{{cell}}</td>
-                    {% endfor %}
-                </tr>
-                {% endfor %}
-            </tbody>
-
-        </table>
-
+        {{ importerTableView(headers, rows) }}
 
         <form action="." method="post">
             <div class="govuk-button-group">

--- a/lib/importer/templates/select_sheet.html
+++ b/lib/importer/templates/select_sheet.html
@@ -19,7 +19,7 @@
             </h1>
           </legend>
           <div class="govuk-radios" data-module="govuk-radios">
-            {{ importerSheetSelector(sheets) }}
+            {{ importerSheetSelector(sheets, selected) }}
           </div>
         </fieldset>
       </div>

--- a/lib/importer/templates/select_sheet.html
+++ b/lib/importer/templates/select_sheet.html
@@ -1,5 +1,7 @@
 {% extends "layouts/main.html" %}
 
+{% from "importer/macros/sheet_selector.njk" import importerSheetSelector %}
+
 {% block pageTitle %} – {{ serviceName }} – GOV.UK Prototype Kit {% endblock %}
 {% block beforeContent %}
 {{ govukBackLink({ text: "Back", href: "javascript:window.history.back()" }) }}
@@ -17,15 +19,7 @@
             </h1>
           </legend>
           <div class="govuk-radios" data-module="govuk-radios">
-            {% for sheet in sheets %}
-            <div class="govuk-radios__item">
-              <input class="govuk-radios__input" id="{{sheet}}" name="sheet" type="radio" value="{{sheet}}" {% if
-                selected==sheet %}checked{% endif %}>
-              <label class="govuk-label govuk-radios__label" for="{{sheet}}">
-                {{sheet}}
-              </label>
-            </div>
-            {% endfor %}
+            {{ importerSheetSelector(sheets) }}
           </div>
         </fieldset>
       </div>

--- a/prototypes/basic/app/views/mapping.html
+++ b/prototypes/basic/app/views/mapping.html
@@ -5,20 +5,7 @@
 {{ govukBackLink({ text: "Back", href: "javascript:window.history.back()" }) }}
 {% endblock %}
 
-{% macro mapping_select(h, fields=[]) %}
-<div class="govuk-grid-column-two-thirds" style="margin-bottom: 1em;">
-    <label class="govuk-label govuk-label--s" style="float:left" for="{{h.name}}">
-        {{ h.name }}
-    </label>
-
-    <select class="govuk-select" style="float: right;" name="{{h.index}}">
-        <option name=""></option>
-        {% for field in fields %}
-        <option value="{{field}}">{{field}}</option>
-        {% endfor %}
-    </select>
-</div>
-{% endmacro %}
+{% from "importer/macros/field_mapper.njk" import importerFieldMapper %}
 
 {% block content %}
 <div class="govuk-grid-row">
@@ -28,9 +15,8 @@
         <h2 class="govuk-heading-m">{{sheet}}</h2>
 
         <form action="." method="post">
-            {% for heading in headings %}
-            {{ mapping_select(heading, fields) }}
-            {% endfor %}
+
+            {{ importerFieldMapper(headings, fields) }}
 
             <div class="govuk-grid-column-two-thirds">
                 <div class="govuk-button-group">

--- a/prototypes/basic/app/views/review.html
+++ b/prototypes/basic/app/views/review.html
@@ -10,6 +10,8 @@
 <script type="text/javascript" src="/plugin-assets/importer/assets/js/keys.js"></script>
 {% endblock %}
 
+{% from "importer/macros/table_view.njk" import importerTableView %}
+
 
 {% block pageTitle %} – {{ serviceName }} – GOV.UK Prototype Kit {% endblock %}
 {% block beforeContent %}
@@ -21,25 +23,7 @@
     <div class="govuk-grid-column-two-thirds">
         <h1 class="govuk-heading-l">Review your data</h1>
 
-
-        <table class="selectable govuk-body">
-            <thead>
-                {% for h in headers %}
-                <th>{{h}}</th>
-                {% endfor %}
-            </thead>
-            <tbody>
-                {% for row in rows %}
-                <tr>
-                    {% for cell in row %}
-                    <td>{{cell}}</td>
-                    {% endfor %}
-                </tr>
-                {% endfor %}
-            </tbody>
-
-        </table>
-
+        {{ importerTableView(headers, rows) }}
 
         <form action="." method="post">
             <div class="govuk-button-group">

--- a/prototypes/basic/app/views/select_sheet.html
+++ b/prototypes/basic/app/views/select_sheet.html
@@ -19,7 +19,7 @@
             </h1>
           </legend>
           <div class="govuk-radios" data-module="govuk-radios">
-            {{ importerSheetSelector(sheets) }}
+            {{ importerSheetSelector(sheets, selected) }}
           </div>
         </fieldset>
       </div>

--- a/prototypes/basic/app/views/select_sheet.html
+++ b/prototypes/basic/app/views/select_sheet.html
@@ -1,5 +1,7 @@
 {% extends "layouts/main.html" %}
 
+{% from "importer/macros/sheet_selector.njk" import importerSheetSelector %}
+
 {% block pageTitle %} – {{ serviceName }} – GOV.UK Prototype Kit {% endblock %}
 {% block beforeContent %}
 {{ govukBackLink({ text: "Back", href: "javascript:window.history.back()" }) }}
@@ -17,15 +19,7 @@
             </h1>
           </legend>
           <div class="govuk-radios" data-module="govuk-radios">
-            {% for sheet in sheets %}
-            <div class="govuk-radios__item">
-              <input class="govuk-radios__input" id="{{sheet}}" name="sheet" type="radio" value="{{sheet}}" {% if
-                selected==sheet %}checked{% endif %}>
-              <label class="govuk-label govuk-radios__label" for="{{sheet}}">
-                {{sheet}}
-              </label>
-            </div>
-            {% endfor %}
+            {{ importerSheetSelector(sheets) }}
           </div>
         </fieldset>
       </div>


### PR DESCRIPTION
Each template in the importer lib has a section that displays data, and to increase flexibility, we have wrapped those elements in nunjucks macros so that designers have more control over what they show and where.  Although they can just take the templates whole, this will also make it possible for them to make library calls and present that data to the macros directly.

