### PR TITLE
Macro for table assets

### DIFF
--- a/lib/importer/govuk-prototype-kit.config.json
+++ b/lib/importer/govuk-prototype-kit.config.json
@@ -44,6 +44,10 @@
     {
       "macroName": "importerTableView",
       "importFrom": "importer/macros/table_view.njk"
+    },
+    {
+      "macroName": "importerTableViewAssets",
+      "importFrom": "importer/macros/table_assets.njk"
     }
   ]
 }

--- a/lib/importer/nunjucks/importer/macros/table_assets.njk
+++ b/lib/importer/nunjucks/importer/macros/table_assets.njk
@@ -1,0 +1,10 @@
+{% macro importerTableViewAssets() %}
+<link href="plugin-assets/%40register-dynamics%2Fimporter/assets/css/selectable_table.css" rel="stylesheet"
+    type="text/css">
+<script type="text/javascript"
+    src="/plugin-assets/%40register-dynamics%2Fimporter/assets/js/selectable_polyfills.js"></script>
+<script type="text/javascript"
+    src="/plugin-assets/%40register-dynamics%2Fimporter/assets/js/selectable_table.js"></script>
+<script type="text/javascript" src="/plugin-assets/%40register-dynamics%2Fimporter/assets/js/class_list.js"></script>
+<script type="text/javascript" src="/plugin-assets/%40register-dynamics%2Fimporter/assets/js/keys.js"></script>
+{% endmacro %}

--- a/lib/importer/package-lock.json
+++ b/lib/importer/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "importer",
-  "version": "1.0.0",
+  "name": "@register-dynamics/importer",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "importer",
-      "version": "1.0.0",
+      "name": "@register-dynamics/importer",
+      "version": "0.1.1",
       "license": "ISC",
       "dependencies": {
         "multer": "^1.4.5-lts.1",

--- a/lib/importer/templates/review.html
+++ b/lib/importer/templates/review.html
@@ -1,13 +1,8 @@
 {% extends "layouts/main.html" %}
 
 {% block head %}
-{{ super() }}
-
-<link href="/plugin-assets/importer/assets/css/selectable_table.css" rel="stylesheet" type="text/css">
-<script type="text/javascript" src="/plugin-assets/importer/assets/js/selectable_polyfills.js"></script>
-<script type="text/javascript" src="/plugin-assets/importer/assets/js/selectable_table.js"></script>
-<script type="text/javascript" src="/plugin-assets/importer/assets/js/class_list.js"></script>
-<script type="text/javascript" src="/plugin-assets/importer/assets/js/keys.js"></script>
+    {{ super() }}
+    {{ importerTableViewAssets() }}
 {% endblock %}
 
 {% from "importer/macros/table_view.njk" import importerTableView %}

--- a/prototypes/basic/app/routes.js
+++ b/prototypes/basic/app/routes.js
@@ -6,6 +6,6 @@ const govukPrototypeKit = require("govuk-prototype-kit");
 const router = govukPrototypeKit.requests.setupRouter();
 
 const cfg = require("govuk-prototype-kit/lib/config");
-const importer = require("importer");
+const importer = require("@register-dynamics/importer");
 
 importer.Initialise(cfg.getConfig(), router, govukPrototypeKit);

--- a/prototypes/basic/app/views/review.html
+++ b/prototypes/basic/app/views/review.html
@@ -1,13 +1,8 @@
 {% extends "layouts/main.html" %}
 
 {% block head %}
-{{ super() }}
-
-<link href="/plugin-assets/importer/assets/css/selectable_table.css" rel="stylesheet" type="text/css">
-<script type="text/javascript" src="/plugin-assets/importer/assets/js/selectable_polyfills.js"></script>
-<script type="text/javascript" src="/plugin-assets/importer/assets/js/selectable_table.js"></script>
-<script type="text/javascript" src="/plugin-assets/importer/assets/js/class_list.js"></script>
-<script type="text/javascript" src="/plugin-assets/importer/assets/js/keys.js"></script>
+    {{ super() }}
+    {{ importerTableViewAssets() }}
 {% endblock %}
 
 {% from "importer/macros/table_view.njk" import importerTableView %}
@@ -15,7 +10,7 @@
 
 {% block pageTitle %} – {{ serviceName }} – GOV.UK Prototype Kit {% endblock %}
 {% block beforeContent %}
-{{ govukBackLink({ text: "Back", href: "javascript:window.history.back()" }) }}
+    {{ govukBackLink({ text: "Back", href: "javascript:window.history.back()" }) }}
 {% endblock %}
 
 {% block content %}

--- a/prototypes/basic/package-lock.json
+++ b/prototypes/basic/package-lock.json
@@ -6,17 +6,21 @@
     "": {
       "dependencies": {
         "@govuk-prototype-kit/common-templates": "2.0.1",
+        "@register-dynamics/importer": "file:../../lib/importer",
         "govuk-frontend": "5.4.1",
-        "govuk-prototype-kit": "13.16.2",
-        "importer": "file:../../lib/importer"
+        "govuk-prototype-kit": "13.16.2"
       }
     },
     "../../lib/importer": {
-      "version": "1.0.0",
+      "name": "@register-dynamics/importer",
+      "version": "0.1.1",
       "license": "ISC",
       "dependencies": {
         "multer": "^1.4.5-lts.1",
         "node-xlsx": "^0.24.0"
+      },
+      "devDependencies": {
+        "jest": "^29.7.0"
       }
     },
     "node_modules/@govuk-prototype-kit/common-templates": {
@@ -59,6 +63,10 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@register-dynamics/importer": {
+      "resolved": "../../lib/importer",
+      "link": true
     },
     "node_modules/@socket.io/component-emitter": {
       "version": "3.1.2",
@@ -1895,10 +1903,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/importer": {
-      "resolved": "../../lib/importer",
-      "link": true
     },
     "node_modules/indent-string": {
       "version": "4.0.0",

--- a/prototypes/basic/package.json
+++ b/prototypes/basic/package.json
@@ -6,8 +6,8 @@
   },
   "dependencies": {
     "@govuk-prototype-kit/common-templates": "2.0.1",
+    "@register-dynamics/importer": "file:../../lib/importer",
     "govuk-frontend": "5.4.1",
-    "govuk-prototype-kit": "13.16.2",
-    "importer": "file:../../lib/importer"
+    "govuk-prototype-kit": "13.16.2"
   }
 }


### PR DESCRIPTION
When using a scoped package (@register-dynamics/importer) the path to load the assets is no longer plugin-assets/importer but now includes the scoped package name.

To resolve this we have introduced a new macro for loading the table assets directly, without the user needing to know what they are.  This might be prettier if we had an obvious way to get the name of the package the code lives in.  We might in future load the package.json and read/encode and use it.