### PR TITLE
Do not remove visual selection when focus is lost

### DIFF
--- a/lib/importer/assets/js/selectable_table.js
+++ b/lib/importer/assets/js/selectable_table.js
@@ -710,10 +710,12 @@ window.addEventListener("load", function() {
          if (event.target.closest("table") !== table) {
            DocumentSelectMode.leave(document);
 
-           // TODO: Determine how we might configure whether to remove the
-           // currently selection when the table loses focus. For now, let's
-           // keep the current visible selection.
-           // applySelection(NilSelection);
+
+          // If we not set the table's data-persist-selection attribute to "true" then we will apply
+          // the Nil selection when the table loses focus.
+          if ( !table.dataset.persistSelection ||  table.dataset.persistSelection.toLowerCase() != "true") {
+            applySelection(NilSelection);
+          }
 
            DocumentUnfocusedMode.enter(document);
          }

--- a/lib/importer/assets/js/selectable_table.js
+++ b/lib/importer/assets/js/selectable_table.js
@@ -542,7 +542,7 @@ window.addEventListener("load", function() {
         if (input) {
             input.focus();
         }
-        
+
         for (var inp of cell.node.querySelectorAll(InputElementsSelector)) {
           InputEditMode.enter(inp);
         }
@@ -707,11 +707,16 @@ window.addEventListener("load", function() {
       DocumentEditMode.addEvent("keydown", editModeKeyboardShortcuts);
 
       var loseFocus = function(event) {
-        if (event.target.closest("table") !== table) {
-          DocumentSelectMode.leave(document);
-          applySelection(NilSelection);
-          DocumentUnfocusedMode.enter(document);
-        }
+         if (event.target.closest("table") !== table) {
+           DocumentSelectMode.leave(document);
+
+           // TODO: Determine how we might configure whether to remove the
+           // currently selection when the table loses focus. For now, let's
+           // keep the current visible selection.
+           // applySelection(NilSelection);
+
+           DocumentUnfocusedMode.enter(document);
+         }
       }
       DocumentSelectMode.addEvent("click", loseFocus);
       var elementsOutsideTable = document.evaluate(FocusableElementsOutsideTable, document, null, XPathResult.UNORDERED_NODE_SNAPSHOT_TYPE, null);

--- a/lib/importer/nunjucks/importer/macros/table_view.njk
+++ b/lib/importer/nunjucks/importer/macros/table_view.njk
@@ -5,7 +5,7 @@
     {% set headers = obj.headers %}
     {% set rows = obj.rows %}
 
-    <table class="selectable govuk-body">
+    <table class="selectable govuk-body" data-persist-selection="true">
         <thead>
             <tr>
             {% for h in headers %}


### PR DESCRIPTION
Currently when the focus is removed from the table, the current visual selection is also removed. Whilst we will have taken what we want from the table at this point (the cell range) it may confuse users to see the selection disappear as they click a nearby submit button.

To configure this behaviour (remember the selection) the table should contain a data attribute called persist-selection like 

```
<table class="selectable" data-persist-selection="true">
```

Any other value, or the absence of the attribute will result in the old behavious of the selection being removed when the table focus is lost.

Resolves #27

