### PR TITLE
Fix non-functional GOV.UK Frontend JS on static site

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,4 +1,9 @@
 PLATFORM := $(shell uname)
+ifeq (${PLATFORM}, Darwin)
+SED_INPLACE_FLAG = -i ''
+endif
+SED_INPLACE_FLAG ?= -i
+
 HQ ?= $(shell which hq)
 ifeq (${HQ},)
 $(error "No hq on the PATH? https://github.com/ludovicianul/hq/releases/tag/hq-1.3.2")
@@ -25,15 +30,12 @@ assets.mk: assets.txt
 
 .PHONY: all
 all: ${OBJECTS} | assets.txt # Rewrite all of the asset paths to be local now.
-ifeq (${PLATFORM}, "Darwin")
 	for ASSET in $$(cat assets.txt); do \
-		sed -i '' -e "s:$$ASSET:$$(basename $$ASSET):" ${OBJECTS}; \
+		sed ${SED_INPLACE_FLAG} -e "s:$$ASSET:$$(basename $$ASSET):" ${OBJECTS}; \
 	done
-else
-	for ASSET in $$(cat assets.txt); do \
-		sed -i "s:$$ASSET:$$(basename $$ASSET):" ${OBJECTS}; \
+	for PATCH in $$(find . -name '*.patch'); do \
+		patch --forward --dry-run $$(basename $$PATCH .patch) $$PATCH && patch --forward $$(basename $$PATCH .patch) $$PATCH || true; \
 	done
-endif
 include assets.mk
 
 # We can generate the .gitignore from all of the things we know we are going to

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,0 +1,27 @@
+# Documentation
+
+See [the documentation site](https://register-dynamics.github.io/data-import)
+for the most up to date information.
+
+## Building the documentation
+
+The code in this folder generates static documentation from the files found in
+[the Prototype Kit plugin](../lib/importer/assets/docs/).
+
+To do this, we run the Prototype Kit with the plugin loaded, get the
+documentation pages that we know exist, work out what assets they all need, and
+then request those too. We do it this way because the documentation can reuse
+assets from the Prototype Kit which are not necessarily even on disk (e.g. some
+CSS is rendered from Sass) so the cleanest way to get those assets is just to
+download them.
+
+There are also some patches that remove the assumptions that the pages are being
+loaded as part of a running Prototype Kit.
+
+The documentation pages contain some HTML elements with `data-plugin-only`
+attributes which are intended to only be seen when the page is running as part
+of the Prototype Kit. This elements are removed as part of this build process.
+
+This requires a copy of [`hq`](https://github.com/ludovicianul/hq/releases)
+which allows us to both remove the plugin only elements and also get the assets
+we need from HTML attributes.

--- a/doc/init.js.patch
+++ b/doc/init.js.patch
@@ -1,0 +1,4 @@
+2c2
+< import * as GOVUKFrontend from '../govuk/govuk-frontend.min.js'
+---
+> import * as GOVUKFrontend from './govuk-frontend.min.js'

--- a/doc/kit.js.patch
+++ b/doc/kit.js.patch
@@ -1,0 +1,2 @@
+26d25
+<   sendPageLoadedRequest()


### PR DESCRIPTION
This was because of some path resolution issues. These have been manually patched for the files in the static site blob.