### PR TITLE
Fix #38 - Ignore blank rows (but report a warning).

### DIFF
--- a/lib/importer/backend.js
+++ b/lib/importer/backend.js
@@ -321,6 +321,9 @@ exports.SessionPerformMappingJob = (sid, range, mapping) => {
     for(let rowIdx=range.start.row; rowIdx <= range.end.row; rowIdx++) {
         let row = data[rowIdx];
         let record = {};
+        let foundSomeValues = false;
+        let rowWarnings = [];
+        let rowErrors = [];
         attrMap.forEach((element) => {
             const [attr, m] = element;
             // For now, attribute mappings are just integer column offsets
@@ -332,9 +335,21 @@ exports.SessionPerformMappingJob = (sid, range, mapping) => {
                 record[attr] = null;
             } else {
                 record[attr] = row[range.start.column + m];
+                foundSomeValues = true;
             }
         });
-        records.push(record);
+        if (foundSomeValues) {
+            records.push(record);
+        } else {
+            rowWarnings.push("Row is blank");
+        }
+
+        if(rowWarnings.length > 0) {
+            warnings.set(rowIdx, rowWarnings);
+        }
+        if(rowErrors.length > 0) {
+            errors.set(rowIdx, rowErrors);
+        }
     }
 
     let jid = makeAccessToken("j");

--- a/lib/importer/sheets.js
+++ b/lib/importer/sheets.js
@@ -92,6 +92,9 @@ exports.MapData = (session, previewLimit = DEFAULT_PREVIEW_LIMIT) => {
         return rowArray;
     });
 
+    warnings = backend.JobGetWarnings(backendJid);
+    errors = backend.JobGetErrors(backendJid);
+
     // FIXME: As we just return up to previewLimit rows, we're throwing the rest
     // away. When used in production, we will either: (a) keep the job so they
     // can be used, (b) get them all and send them somewhere, or (c) throw them
@@ -105,6 +108,10 @@ exports.MapData = (session, previewLimit = DEFAULT_PREVIEW_LIMIT) => {
     return {
         resultRecords: resultsAsArrays,
         totalCount: resultSummary.recordCount,
-        extraRecordCount: resultSummary.recordCount-recordsToPreview
+        extraRecordCount: resultSummary.recordCount-recordsToPreview,
+        warningCount: resultSummary.warningCount,
+        errorCount: resultSummary.errorCount,
+        warnings: warnings,
+        errors: errors
     }
 }


### PR DESCRIPTION
Also obtains warning/error data from the backend and makes it available to the frontend macros, although nothing is currently done with it.