### PR TITLE
Fix #44: Always present the (at most) top 10 rows of the sheet in range selection

### DIFF
--- a/lib/importer/sheets.js
+++ b/lib/importer/sheets.js
@@ -149,13 +149,12 @@ exports.GetRows = (session, start=0, count=10) => {
   const sheetDimensions = backend.SessionGetInputDimensions(session.backendSid)
         .sheetDimensions.get(session.sheet);
 
-  // We have to calculate the range containing the data based on what we believe
-  // the header range to be.
-  const hRange = session.headerRange;
+  // Try to provide rows from start to start+count-1, but limit ourselves to
+  // the rows in the sheet.
   const rowRange = {
     sheet: session.sheet,
-    start: { row: hRange.start.row, column: hRange.start.column},
-    end: { row: sheetDimensions.rows - (hRange.end.row + 1), column: hRange.end.column}
+    start: { row: start, column: 0},
+    end: { row: Math.min(start + count - 1, sheetDimensions.rows-1), column: sheetDimensions.columns-1}
   }
 
   const preview = backend.SessionGetInputSampleRows(session.backendSid, rowRange, count, 0, 0)[0];


### PR DESCRIPTION
Previously, we were selecting rows based on the currently selected range, which was OK when the default initial header range was selected, but problematic when the user had already selected a header range.

Resolves #44.