### PR TITLE
Bypass Node XLSX

### DIFF
--- a/lib/importer/backend.js
+++ b/lib/importer/backend.js
@@ -39,21 +39,12 @@ exports.CreateSession = () => {
 // Set the filename of the file for an import session.
 exports.SessionSetFile = (sid, filename) => {
     const wb = xlsx.readFile(filename, {dense: true});
-    const sheets = new Map();
-    Object.keys(wb.Sheets).forEach((name) => {
-        const sheet = wb.Sheets[name];
-        const json = xlsx.utils.sheet_to_json(sheet, {
-            raw: true,
-            header: 1});
-        sheets.set(name, json);
-    });
 
     let session = {
         filename: filename,
         wb: wb,
         sheetNames: Array.from(Object.keys(wb.Sheets)),
         jobs: new Set(),
-        sheets: sheets,
     }
     sessionStore.set(sid, session);
 };
@@ -232,7 +223,7 @@ function cellsToSamples(row) {
 // This function reserves the right to return fewer than requested rows.
 exports.SessionGetInputSampleRows = (sid, range, startCount, middleCount, endCount) => {
     assert(sessionStore.has(sid));
-    assert(sessionStore.get(sid).sheets.has(range.sheet));
+    assert(sessionStore.get(sid).wb.Sheets[range.sheet]);
     assert(range.end.row >= range.start.row);
     assert(range.end.column >= range.start.column);
     // If the caller asked for more rows than we have, or if the start/middle/end would overlap, clamp the counts
@@ -279,7 +270,7 @@ exports.SessionGetInputSampleRows = (sid, range, startCount, middleCount, endCou
 // truncated to maxValues.
 exports.SessionGetInputValues = (sid, range, maxValues) => {
     assert(sessionStore.get(sid));
-    assert(sessionStore.get(sid).sheets.has(range.sheet));
+    assert(sessionStore.get(sid).wb.Sheets[range.sheet]);
     assert(range.end.row >= range.start.row);
     assert(range.end.column >= range.start.column);
 
@@ -354,7 +345,7 @@ function mapCellValue(cell) {
 
 exports.SessionPerformMappingJob = (sid, range, mapping) => {
     assert(sessionStore.get(sid));
-    assert(sessionStore.get(sid).sheets.has(range.sheet));
+    assert(sessionStore.get(sid).wb.Sheets[range.sheet]);
     assert(range.end.row >= range.start.row);
     assert(range.end.column >= range.start.column);
 
@@ -373,19 +364,22 @@ exports.SessionPerformMappingJob = (sid, range, mapping) => {
         let foundSomeValues = false;
         let rowWarnings = [];
         let rowErrors = [];
-        attrMap.forEach((element) => {
-            const [attr, m] = element;
-            // For now, attribute mappings are just integer column offsets
-            const inputColumn = range.start.column + m;
-            if (inputColumn >= row.length) {
-                // If a row is missing values at the end, this may be
-                // represented as a "short" row array.
-                record[attr] = undefined;
-            } else {
-                record[attr] = mapCellValue(row[range.start.column + m]);
-                foundSomeValues = true;
-            }
-        });
+        if (row) {
+            attrMap.forEach((element) => {
+                const [attr, m] = element;
+                // For now, attribute mappings are just integer column offsets
+                const inputColumn = range.start.column + m;
+                if (inputColumn >= row.length) {
+                    // If a row is missing values at the end, this may be
+                    // represented as a "short" row array.
+                    record[attr] = undefined;
+                } else {
+                    record[attr] = mapCellValue(row[range.start.column + m]);
+                    foundSomeValues = true;
+                }
+            });
+        }
+
         if (foundSomeValues) {
             records.push(record);
         } else {

--- a/lib/importer/backend.js
+++ b/lib/importer/backend.js
@@ -38,7 +38,7 @@ exports.CreateSession = () => {
 
 // Set the filename of the file for an import session.
 exports.SessionSetFile = (sid, filename) => {
-    const wb = xlsx.readFile(filename, {dense: true});
+    const wb = xlsx.readFile(filename, {dense: true, cellStyles: true});
 
     let session = {
         filename: filename,
@@ -374,16 +374,17 @@ exports.SessionPerformMappingJob = (sid, range, mapping) => {
                     // represented as a "short" row array.
                     record[attr] = undefined;
                 } else {
-                    record[attr] = mapCellValue(row[range.start.column + m]);
-                    foundSomeValues = true;
+                    const cell = row[range.start.column + m];
+                    if(cell.v) {
+                        record[attr] = mapCellValue(cell);
+                        foundSomeValues = true;
+                    }
                 }
             });
         }
 
         if (foundSomeValues) {
             records.push(record);
-        } else {
-            rowWarnings.push("Row is blank");
         }
 
         if(rowWarnings.length > 0) {

--- a/lib/importer/backend.js
+++ b/lib/importer/backend.js
@@ -1,4 +1,4 @@
-const xlsx = require("node-xlsx").default;
+const xlsx = require("xlsx");
 const crypto = require("crypto");
 const assert = require('node:assert').strict;
 
@@ -38,28 +38,35 @@ exports.CreateSession = () => {
 
 // Set the filename of the file for an import session.
 exports.SessionSetFile = (sid, filename) => {
-    const data = xlsx.parse(filename);
+    const wb = xlsx.readFile(filename, {dense: true});
+    const sheets = new Map();
+    Object.keys(wb.Sheets).forEach((name) => {
+        const sheet = wb.Sheets[name];
+        const json = xlsx.utils.sheet_to_json(sheet, {
+            raw: true,
+            header: 1});
+        sheets.set(name, json);
+    });
+
     let session = {
         filename: filename,
-        data: data,
+        wb: wb,
+        sheetNames: Array.from(Object.keys(wb.Sheets)),
         jobs: new Set(),
-        sheets: new Map(),
+        sheets: sheets,
     }
-    data.forEach((sheet) => {
-        session.sheets.set(sheet.name, sheet.data);
-    });
     sessionStore.set(sid, session);
 };
 
 function getDimensions(sid) {
-    let data = sessionStore.get(sid).data;
+    let data = sessionStore.get(sid);
     let sheetDimensions = new Map();
-    data.forEach((sheet) => {
-        sheetDimensions.set(sheet.name, {
-            rows: sheet.data.length,
-            columns: sheet.data.reduce(
-                (maxLength, currentRow) => Math.max(maxLength, currentRow.length),
-                0)
+    Object.keys(data.wb.Sheets).forEach((sheetName) => {
+        const sheet = data.wb.Sheets[sheetName];
+        const range = xlsx.utils.decode_range(sheet["!ref"]);
+        sheetDimensions.set(sheetName, {
+            rows: range.e.r+1,
+            columns: range.e.c+1
         });
     });
     return {
@@ -165,7 +172,7 @@ exports.SessionSuggestDataRange = (sid, headerRange, footerRange) => {
         }
     } else {
         // No header range specified, so take all but the first row of the first sheet
-        const sheetName = sessionStore.get(sid).data[0].name; // Find the first sheet
+        const sheetName = sessionStore.get(sid).sheetNames[0]; // Find the first sheet
         const sheetDimensions = dimensions.sheetDimensions.get(sheetName);
         return {
             sheet: sheetName,
@@ -200,7 +207,20 @@ function sliceAndPad(row, start, end) {
 }
 
 function sliceAndPadRows(rows, start, end) {
-    return rows.map((row) => sliceAndPad(row, start, end));
+    const slicedAndPaddedRows = rows.map((row) => sliceAndPad(row, start, end));
+    return slicedAndPaddedRows;
+}
+
+// Convert a sheet.js cell object to a string for display in an input sample
+function cellToSample(c) {
+    if(c)
+        return c.w;
+    else
+        return undefined;
+}
+
+function cellsToSamples(row) {
+    return row.map(cellToSample);
 }
 
 // Returns a sample of rows in a range. range is of the form {sheet: 'Foo', start:{row: X, column: Y}, end:{row: X, column: Y}}.
@@ -219,7 +239,7 @@ exports.SessionGetInputSampleRows = (sid, range, startCount, middleCount, endCou
     const totalRowsInRange = (range.end.row - range.start.row + 1);
     [startCount, middleCount, endCount] = clampCounts(startCount, middleCount, endCount, totalRowsInRange);
 
-    let data = sessionStore.get(sid).sheets.get(range.sheet);
+    let data = sessionStore.get(sid).wb.Sheets[range.sheet]["!data"];
 
     // Extract initial rows
     let startRows = sliceAndPadRows(data.slice(range.start.row, range.start.row+startCount),
@@ -247,9 +267,9 @@ exports.SessionGetInputSampleRows = (sid, range, startCount, middleCount, endCou
     // form, and because styling information might be a significant part of the
     // data.
 
-    return [startRows,
-            middleRows,
-            endRows];
+    return [startRows.map(cellsToSamples),
+            middleRows.map(cellsToSamples),
+            endRows.map(cellsToSamples)];
 };
 
 // Return the unique values in each column in the range. Return no more than
@@ -263,7 +283,8 @@ exports.SessionGetInputValues = (sid, range, maxValues) => {
     assert(range.end.row >= range.start.row);
     assert(range.end.column >= range.start.column);
 
-    let data = sessionStore.get(sid).sheets.get(range.sheet);
+    let data = sessionStore.get(sid).wb.Sheets[range.sheet]["!data"];
+
     let result = new Array(range.end.column - range.start.column + 1);
     let resultIdx = 0;
 
@@ -272,7 +293,7 @@ exports.SessionGetInputValues = (sid, range, maxValues) => {
         let hasMore = false;
 
         for(let row = range.start.row; row <= range.end.row; row++) {
-            let value = data[row][col];
+            let value = cellToSample(data[row][col]);
 
             if (values.size < maxValues) {
                 // There's room for more, keep shovelling them in
@@ -326,6 +347,11 @@ function validateMapping(range, mapping) {
     }
 }
 
+function mapCellValue(cell) {
+    // FIXME: Be aware of the destination type, and of any other mapping operations configured by the user
+    return cell.v;
+}
+
 exports.SessionPerformMappingJob = (sid, range, mapping) => {
     assert(sessionStore.get(sid));
     assert(sessionStore.get(sid).sheets.has(range.sheet));
@@ -338,7 +364,7 @@ exports.SessionPerformMappingJob = (sid, range, mapping) => {
     let errors = new Map(); // Maps input row number to list of errors
     let warnings = new Map(); // Maps input row number to list of warnings
 
-    let data = sessionStore.get(sid).sheets.get(range.sheet);
+    let data = sessionStore.get(sid).wb.Sheets[range.sheet]["!data"];
     let attrMap = Object.entries(mapping.attributeMappings);
 
     for(let rowIdx=range.start.row; rowIdx <= range.end.row; rowIdx++) {
@@ -356,7 +382,7 @@ exports.SessionPerformMappingJob = (sid, range, mapping) => {
                 // represented as a "short" row array.
                 record[attr] = undefined;
             } else {
-                record[attr] = row[range.start.column + m];
+                record[attr] = mapCellValue(row[range.start.column + m]);
                 foundSomeValues = true;
             }
         });

--- a/lib/importer/backend.test.js
+++ b/lib/importer/backend.test.js
@@ -22,15 +22,15 @@ test('happy path', () => {
     const samples = backend.SessionGetInputSampleRows(sid, dataRange,
                                                       1, 1, 1);
     expect(samples).toMatchObject([
-        [ [ 'Boris', 13, 'High' ] ],
-        [ [ 'Nelly', 14, 'High' ] ],
-        [ [ 'Sid', 10, 'Medium' ] ]
+        [ [ 'Boris', '13', 'High' ] ],
+        [ [ 'Nelly', '14', 'High' ] ],
+        [ [ 'Sid', '10', 'Medium' ] ]
     ]);
 
     const values = backend.SessionGetInputValues(sid, dataRange, 2);
     expect(values).toMatchObject([
         { values: [ 'Boris', 'Nelly' ], hasMore: true },
-        { values: [ 13, 14 ], hasMore: true },
+        { values: [ '13', '14' ], hasMore: true },
         { values: [ 'High', 'Medium' ], hasMore: false }
     ]);
 
@@ -92,9 +92,9 @@ test('pad narrow samples', () => {
     const samples = backend.SessionGetInputSampleRows(sid, dataRange,
                                                       1, 1, 1);
     expect(samples).toMatchObject([
-        [ [ 'Boris', 13, 'High', undefined ] ],
-        [ [ 'Nelly', 14, 'High', undefined ] ],
-        [ [ 'Sid', 10, 'Medium', undefined ] ]
+        [ [ 'Boris', '13', 'High', undefined ] ],
+        [ [ 'Nelly', '14', 'High', undefined ] ],
+        [ [ 'Sid', '10', 'Medium', undefined ] ]
     ]);
 });
 
@@ -150,19 +150,19 @@ test('sample clamping', () => {
     const samples1 = backend.SessionGetInputSampleRows(sid, dataRange,
                                                       10, 10, 10);
     expect(samples1).toMatchObject([
-        [ [ 'Boris', 13, 'High' ] ],
+        [ [ 'Boris', '13', 'High' ] ],
         [ ],
-        [ [ 'Nelly', 14, 'High' ],
-          [ 'Sid', 10, 'Medium' ] ]
+        [ [ 'Nelly', '14', 'High' ],
+          [ 'Sid', '10', 'Medium' ] ]
     ]);
 
     // Let's see if only middleCount is clamped if startCount and endCount are reasonable
     const samples2 = backend.SessionGetInputSampleRows(sid, dataRange,
                                                       1, 10, 1);
     expect(samples2).toMatchObject([
-        [ [ 'Boris', 13, 'High' ] ],
-        [ [ 'Nelly', 14, 'High' ] ],
-        [ [ 'Sid', 10, 'Medium' ] ]
+        [ [ 'Boris', '13', 'High' ] ],
+        [ [ 'Nelly', '14', 'High' ] ],
+        [ [ 'Sid', '10', 'Medium' ] ]
     ]);
 
     // Ok, now check the same works for job result sampling
@@ -221,9 +221,9 @@ test('sampling algorithm', () => {
     expect(samples1[1]).toHaveLength(3);
     expect(samples1[2]).toHaveLength(0);
     expect(samples1[1]).toMatchObject([
-        [ 'Boris', 13, 'High' ],
-        [ 'Nelly', 14, 'High' ],
-        [ 'Sid', 10, 'Medium' ]]);
+        [ 'Boris', '13', 'High' ],
+        [ 'Nelly', '14', 'High' ],
+        [ 'Sid', '10', 'Medium' ]]);
 
     // Now pick 1
     const samples2 = backend.SessionGetInputSampleRows(sid, dataRange,
@@ -234,9 +234,9 @@ test('sampling algorithm', () => {
     expect(samples2[1]).toHaveLength(1);
     expect(samples2[2]).toHaveLength(0);
     expect([
-        [ 'Boris', 13, 'High' ],
-        [ 'Nelly', 14, 'High' ],
-        [ 'Sid', 10, 'Medium' ]]).toContainEqual(samples2[1][0]);
+        [ 'Boris', '13', 'High' ],
+        [ 'Nelly', '14', 'High' ],
+        [ 'Sid', '10', 'Medium' ]]).toContainEqual(samples2[1][0]);
 
     // FIXME: Do 100 samples of 1 record, ensuring we get a roughly equal distribution of results
 
@@ -250,11 +250,11 @@ test('sampling algorithm', () => {
     expect(samples3[1]).toHaveLength(2);
     expect(samples3[2]).toHaveLength(0);
     expect([ // Sid can't be first, if there's two rows and they're in order
-        [ 'Boris', 13, 'High' ],
-        [ 'Nelly', 14, 'High' ]]).toContainEqual(samples3[1][0]);
+        [ 'Boris', '13', 'High' ],
+        [ 'Nelly', '14', 'High' ]]).toContainEqual(samples3[1][0]);
     expect([ // Boris can't be second, if there's two rows and they're in order
-        [ 'Nelly', 14, 'High' ],
-        [ 'Sid', 10, 'Medium' ]]).toContainEqual(samples3[1][1]);
+        [ 'Nelly', '14', 'High' ],
+        [ 'Sid', '10', 'Medium' ]]).toContainEqual(samples3[1][1]);
     // Test they're not equal.
     expect(samples3[1][0]).not.toMatchObject(samples3[1][1]);
 });

--- a/lib/importer/package-lock.json
+++ b/lib/importer/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "multer": "^1.4.5-lts.1",
-        "node-xlsx": "^0.24.0"
+        "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz"
       },
       "devDependencies": {
         "jest": "^29.7.0"
@@ -3106,21 +3106,6 @@
       "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/node-xlsx": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/node-xlsx/-/node-xlsx-0.24.0.tgz",
-      "integrity": "sha512-1olwK48XK9nXZsyH/FCltvGrQYvXXZuxVitxXXv2GIuRm51aBi1+5KwR4rWM4KeO61sFU+00913WLZTD+AcXEg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz"
-      },
-      "bin": {
-        "node-xlsx": "dist/bin/cli.js"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",

--- a/lib/importer/package.json
+++ b/lib/importer/package.json
@@ -19,7 +19,7 @@
   "description": "",
   "dependencies": {
     "multer": "^1.4.5-lts.1",
-    "node-xlsx": "^0.24.0"
+    "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz"
   },
   "devDependencies": {
     "jest": "^29.7.0"


### PR DESCRIPTION
This bypasses the `node-xlsx` library and just uses the underlying sheet.js library, so we can get access to extra metadata.

- This also means that we have access to the 'formatted string' version of a cell, so use that in the preview, which is nice for dates
- But mainly it should change nothing else in the frontend, and provides a basis for us to handle merged cells and access style information in future PRs

Resolves #35. 