### PR TITLE
Show sample column values when mapping fields

### DIFF
--- a/lib/importer/backend.js
+++ b/lib/importer/backend.js
@@ -288,7 +288,7 @@ exports.SessionGetInputValues = (sid, range, maxValues) => {
         }
 
         // Convert the result to a sorted array, for neatness and consistency
-        result[resultIdx] = { values: Array.from(values.values()).sort(),
+        result[resultIdx] = { inputValues: Array.from(values.values()).sort(),
                               hasMore: hasMore };
         resultIdx++;
     }

--- a/lib/importer/backend.test.js
+++ b/lib/importer/backend.test.js
@@ -29,9 +29,9 @@ test('happy path', () => {
 
     const values = backend.SessionGetInputValues(sid, dataRange, 2);
     expect(values).toMatchObject([
-        { values: [ 'Boris', 'Nelly' ], hasMore: true },
-        { values: [ 13, 14 ], hasMore: true },
-        { values: [ 'High', 'Medium' ], hasMore: false }
+        { inputValues: [ 'Boris', 'Nelly' ], hasMore: true },
+        { inputValues: [ 13, 14 ], hasMore: true },
+        { inputValues: [ 'High', 'Medium' ], hasMore: false }
     ]);
 
     const mapping = {
@@ -47,7 +47,7 @@ test('happy path', () => {
     const jid = backend.SessionPerformMappingJob(sid, dataRange, mapping);
 
     // Look at the job results
-    
+
     const jobSummary = backend.JobGetSummary(jid);
     expect(jobSummary).toMatchObject({
         recordCount: 3,
@@ -240,7 +240,7 @@ test('sampling algorithm', () => {
 
     // FIXME: Do 100 samples of 1 record, ensuring we get a roughly equal distribution of results
 
-    
+
     // Now pick 2
     const samples3 = backend.SessionGetInputSampleRows(sid, dataRange,
                                                        0, 2, 0);

--- a/lib/importer/index.js
+++ b/lib/importer/index.js
@@ -93,8 +93,7 @@ exports.Initialise = (config, router, prototypeKit) => {
     } else {
       response.data = header_names.map((elem, index, _arr) => {
         let examples = sheets_lib.GetColumnValues(session, index, cellWidth=20, count=5).inputValues
-        let exampleString = examples.join(", ");
-        exampleString = exampleString.substring(0, exampleString.length -1)
+        let exampleString = examples.join(", ").trim().slice(0, -1);
 
         return {
           index: index,

--- a/lib/importer/index.js
+++ b/lib/importer/index.js
@@ -91,7 +91,15 @@ exports.Initialise = (config, router, prototypeKit) => {
     if (!header_names || header_names.length == 0) {
       response.error = {text: "Unable to detect header rows"}
     } else {
-      response.data = header_names.map((elem, index, _arr) => ({index: index, name: elem}))
+      response.data = header_names.map((elem, index, _arr) => {
+        let examples = sheets_lib.GetColumnValues(session, index, cellWidth=20, count=5).inputValues
+
+        return {
+          index: index,
+          name: elem,
+          examples: examples
+        }
+      })
     }
 
     return response

--- a/lib/importer/index.js
+++ b/lib/importer/index.js
@@ -93,11 +93,13 @@ exports.Initialise = (config, router, prototypeKit) => {
     } else {
       response.data = header_names.map((elem, index, _arr) => {
         let examples = sheets_lib.GetColumnValues(session, index, cellWidth=20, count=5).inputValues
+        let exampleString = examples.join(", ");
+        exampleString = exampleString.substring(0, exampleString.length -1)
 
         return {
           index: index,
           name: elem,
-          examples: examples
+          examples: exampleString
         }
       })
     }

--- a/lib/importer/nunjucks/importer/macros/field_mapper.njk
+++ b/lib/importer/nunjucks/importer/macros/field_mapper.njk
@@ -14,7 +14,7 @@
     data submitted from forms to the backend, and also the current
     data import session.
 #}
-{% macro importerFieldMapper(data, caption='Choose which field each column maps to', columnTitle='Column', examplesTitle='Example values', fieldsTitle='Fields') %}
+{% macro importerFieldMapper(data, caption='', columnTitle='Column', examplesTitle='Example values', fieldsTitle='Fields') %}
     {% set fields = data['importer.session']['fields'] %}
     {% set headings = importerGetHeaders(data) %}
     {% set error = headings.error %}

--- a/lib/importer/nunjucks/importer/macros/field_mapper.njk
+++ b/lib/importer/nunjucks/importer/macros/field_mapper.njk
@@ -1,17 +1,17 @@
 
-{# 
-    importerFieldMapper shows each column heading from the current 
-    spreadsheet alongside a drop-down containing each of the fields 
-    for our target object.  This allows the user to choose a target 
-    object field for each column to select how the column->field 
+{#
+    importerFieldMapper shows each column heading from the current
+    spreadsheet alongside a drop-down containing each of the fields
+    for our target object.  This allows the user to choose a target
+    object field for each column to select how the column->field
     mapping should be applied.
 
-    The resulting data to be submitted to the 'importerMapDataPath' 
+    The resulting data to be submitted to the 'importerMapDataPath'
     will be a map of column indices to target field names.
-    
-    It accepts a data object which is taken from the prototype kit's 
-    session data which is made available on every page, and contains the 
-    data submitted from forms to the backend, and also the current 
+
+    It accepts a data object which is taken from the prototype kit's
+    session data which is made available on every page, and contains the
+    data submitted from forms to the backend, and also the current
     data import session.
 #}
 {% macro importerFieldMapper(data) %}
@@ -27,7 +27,7 @@
 
 
     {% for h in headings.data %}
-        <div class="govuk-grid-column-two-thirds" style="margin-bottom: 1em;">
+        <div class="govuk-grid-column-two-thirds">
             <label class="govuk-label govuk-label--s" style="float:left" for="{{h.name}}">
                 {{ h.name }}
             </label>
@@ -38,6 +38,9 @@
                 <option value="{{field}}">{{field}}</option>
                 {% endfor %}
             </select>
+        </div>
+        <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-6 govuk-hint" >
+            Sample values: {{ h.examples }}
         </div>
     {% endfor %}
 {% endmacro %}

--- a/lib/importer/nunjucks/importer/macros/field_mapper.njk
+++ b/lib/importer/nunjucks/importer/macros/field_mapper.njk
@@ -14,7 +14,7 @@
     data submitted from forms to the backend, and also the current
     data import session.
 #}
-{% macro importerFieldMapper(data) %}
+{% macro importerFieldMapper(data, caption='Choose which field each column maps to', columnTitle='Column', examplesTitle='Example values', fieldsTitle='Fields') %}
     {% set fields = data['importer.session']['fields'] %}
     {% set headings = importerGetHeaders(data) %}
     {% set error = headings.error %}
@@ -26,21 +26,36 @@
     {% endif %}
 
 
+<table class="govuk-table">
+  {% if caption %}
+  <caption class="govuk-table__caption govuk-table__caption--m">{{caption}}</caption>
+  {% endif %}
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header">{{columnTitle}}</th>
+      <th scope="col" class="govuk-table__header">{{examplesTitle}}</th>
+      <th scope="col" class="govuk-table__header" style="padding-left: 1.5em">{{fieldsTitle}}</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
     {% for h in headings.data %}
-        <div class="govuk-grid-column-two-thirds">
-            <label class="govuk-label govuk-label--s" style="float:left" for="{{h.name}}">
-                {{ h.name }}
-            </label>
-
-            <select class="govuk-select" style="float: right;" name="{{h.index}}">
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">{{ h.name }}</th>
+      <td class="govuk-table__cell">{{ h.examples }}</td>
+      <td class="govuk-table__cell govuk-table__cell--numeric">
+         <select class="govuk-select" style="float: right;" name="{{h.index}}">
                 <option name=""></option>
                 {% for field in fields %}
                 <option value="{{field}}">{{field}}</option>
                 {% endfor %}
             </select>
-        </div>
-        <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-6 govuk-hint" >
-            Sample values: {{ h.examples }}
-        </div>
+      </td>
+    </tr>
     {% endfor %}
+  </tbody>
+</table>
+
+
+
+
 {% endmacro %}

--- a/lib/importer/sheets.js
+++ b/lib/importer/sheets.js
@@ -45,6 +45,37 @@ exports.GetRows = (session, start=0, count=10) => {
 };
 
 
+exports.GetColumnValues = (session, columnIndex, cellWidth=30, count=10) => {
+    let values = backend.SessionGetInputValues(
+        session.backendSid,
+        {
+            sheet: session.sheet,
+            start: {row: 1, column: session.headerRange.start.column + columnIndex},
+            end: {row:count + 1, column: session.headerRange.start.column + columnIndex}
+        },
+        count
+    )[0];
+
+    if (values.inputValues && cellWidth > 0) {
+        values.inputValues = values.inputValues.map((v) => {
+            if (v && v.length > cellWidth) {
+                return v.substring(0, cellWidth ) + ".."
+            } else {
+                return v
+            }
+        });
+    }
+
+    return values;
+};
+// Return the unique values in each column in the range. Return no more than
+// maxValues values for any given column. Return format is an array, one entry
+// per column, whose entries have a .values property that's an array of values
+// and a .hasMore property that's a boolean set if the values array was
+// truncated to maxValues.
+// exports.SessionGetInputValues = (sid, range, maxValues) => {
+
+
 // Uses the session provided, which must contain a sheet name and a
 // mapping to perform the mapping of the data across the remaining
 // rows in the sheet to return an array of objects.


### PR DESCRIPTION
Shows a sample of the possible values for each column when mapping from columns to fields.

Optionally allows a limited number of sample items to be shown, and also to truncate each value so that the samples don't show extremely long strings across multiple lines.

![–_Import_spreadsheet_data_–_GOV_UK_Prototype_Kit](https://github.com/user-attachments/assets/daea3e7f-becb-4983-add2-3976b2ce6b74)

In this screenshot the caption is optional and configurable (defaults to ''), and the text used for each table heading is also configurable in the macro using ...

```js
importerFieldMapper(
    data, 
    caption='', 
    columnTitle='Column', 
    examplesTitle='Example values', 
    fieldsTitle='Fields'
)
```

## TODO:

* [ ] Make sure returned items are only optionally sorted


