### PR TITLE
Normalise the header selection

### DIFF
--- a/lib/importer/index.js
+++ b/lib/importer/index.js
@@ -236,10 +236,18 @@ exports.Initialise = (config, router, prototypeKit) => {
     // We should probably find a better way of handling no selection, and we still
     // need to decide how users can decide between auto-choose header and user-chosen
     // headers.
-    let tlRow = request.body['importer:selection:TLRow'] ?? 0;
-    let tlCol = request.body['importer:selection:TLCol'] ?? 0;
-    let brRow = request.body['importer:selection:BRRow'] ?? 0;
-    let brCol = request.body['importer:selection:BRCol'] ?? maxCol;
+    let tlRow = getIntOrDefault(request.body['importer:selection:TLRow']);
+    let tlCol = getIntOrDefault(request.body['importer:selection:TLCol']);
+    let brRow = getIntOrDefault(request.body['importer:selection:BRRow']);
+    let brCol = getIntOrDefault(request.body['importer:selection:BRCol'], maxCol);
+
+    // Normalise the selection so that start row <= end row and start col <= end col
+    if (tlRow > brRow) {
+      [tlRow, brRow] = [brRow, tlRow];
+    }
+    if (tlCol > brCol) {
+      [tlCol, brCol] = [brCol, tlCol];
+    }
 
     session.headerRange = {
       sheet: session.sheet,
@@ -251,8 +259,6 @@ exports.Initialise = (config, router, prototypeKit) => {
     request.session.data[IMPORTER_SESSION_KEY] = session;
     redirectOnwards(request, response);
   });
-
-
 
 
   //--------------------------------------------------------------------
@@ -273,6 +279,7 @@ exports.Initialise = (config, router, prototypeKit) => {
     request.session.data[IMPORTER_SESSION_KEY] = session;
     redirectOnwards(request, response);
   });
+
 
   //--------------------------------------------------------------------
   // Review the processing for the current session before continuing.
@@ -320,3 +327,14 @@ exports.CreateSession = session_lib.CreateSession;
 exports.GetSession = session_lib.GetSession;
 exports.UpdateSession = session_lib.UpdateSession;
 exports.ListSessions = session_lib.ListSessions;
+
+//--------------------------------------------------------------------
+// Parse the given key into an int if it is truthy, or returns the
+// default value (whose default is 0)
+//--------------------------------------------------------------------
+const getIntOrDefault = (key, dflt=0) => {
+  if (key) {
+    return parseInt(key)
+  }
+  return dflt;
+};


### PR DESCRIPTION
If we select from right to left, then the selection is invalid when used later on.  To avoid this we normalise it to ensure that the top left elements are less than or equal to the bottom right elements.

Resolves #49 

TODO: When we work on the footer selection we will abstract this code out as it will be re-used there.