### PR TITLE
Accessibility improvements to sheet selector component

### DIFF
--- a/lib/importer/assets/css/selectable_table.css
+++ b/lib/importer/assets/css/selectable_table.css
@@ -6,6 +6,10 @@ table.selectable {
     line-height: 20px
 }
 
+table.selectable caption {
+    text-align: inherit;
+}
+
 table.selectable col:not(:first-child) {
     min-width: 120px
 }

--- a/lib/importer/assets/css/sheet_selector.css
+++ b/lib/importer/assets/css/sheet_selector.css
@@ -1,0 +1,16 @@
+.rd-sheet-selector-previews {
+    display: grid;
+}
+
+.rd-sheet-selector-previews>* {
+    visibility: hidden;
+    z-index: -1;
+    overflow-x: auto;
+    grid-row: 1;
+    grid-column: 1;
+}
+
+.rd-sheet-selector-previews .selected {
+    visibility: visible;
+    z-index: 0;
+}

--- a/lib/importer/assets/js/sheet_selector.js
+++ b/lib/importer/assets/js/sheet_selector.js
@@ -1,0 +1,24 @@
+window.addEventListener("load", () => {
+    const previews = Array.from(document.getElementsByClassName("rd-sheet-selector-previews")[0].children);
+
+    const preview = (elem) => {
+        let index = parseInt(elem.dataset.previewIndex ?? -1);
+        if (index < 0) {
+            return;
+        }
+
+        previews.forEach((p) => {
+            p.classList.remove("selected");
+            p.ariaHidden = true;
+        });
+        previews[index].classList.add("selected");
+        previews[index].ariaHidden = false;
+    }
+
+    const radios = Array.from(document.querySelectorAll('.rd-sheet-preview input[type="radio"]'))
+    radios.forEach(radio => radio.addEventListener("click", () => preview(radio)))
+
+    // Show the preview for any default selected option when the page loads
+    const currentlySelected = document.querySelector('.rd-sheet-preview input[type="radio"]:checked');
+    preview(currentlySelected);
+});

--- a/lib/importer/govuk-prototype-kit.config.json
+++ b/lib/importer/govuk-prototype-kit.config.json
@@ -37,9 +37,11 @@
     "/assets/js/class_list.js",
     "/assets/js/keys.js",
     "/assets/js/selectable_polyfills.js",
+    "/assets/js/sheet_selector.js",
     "/assets/js/selectable_table.js"
   ],
   "stylesheets": [
+    "/assets/css/sheet_selector.css",
     "/assets/css/selectable_table.css"
   ],
   "nunjucksPaths": [

--- a/lib/importer/nunjucks/importer/macros/sheet_selector.njk
+++ b/lib/importer/nunjucks/importer/macros/sheet_selector.njk
@@ -23,10 +23,6 @@
   {% set tableRowIndex = sheets.length + 2 %}
   {% set error = importerError(data) %}
 
-  <style>
-  div.selectable { display: none; overflow-x: auto}
-  </style>
-
   <div class="govuk-form {% if error %}govuk-form-group--error{% endif %}">
     <div class="govuk-form-group ">
       {% if legend %}
@@ -46,49 +42,28 @@
       <div class="govuk-radios rd-sheet-preview" data-module="govuk-radios">
         {% for sheet in sheets %}
         <div class="govuk-radios__item">
-          <input class="govuk-radios__input" id="{{sheet.name}}" name="sheet" type="radio" value="{{sheet.name}}" {% if selectedSheet==sheet.name %}checked="checked"{% endif %} data-preview-index="{{loop.index0}}" onclick="javascript:preview(this);">
+          <input class="govuk-radios__input" id="{{sheet.name}}" name="sheet" type="radio" value="{{sheet.name}}" {% if selectedSheet==sheet.name %}checked="checked"{% endif %} data-preview-index="{{loop.index0}}">
           <label class="govuk-label govuk-radios__label" for="{{sheet.name}}">
           {{sheet.name}}
           </label>
         </div> <!-- .govuk-radios__item  -->
         {% endfor %}
       </div> <!-- .govuk-radios  -->
-  </div>
-</div>
-
-<div id="previews" class="govuk-!-margin-top-6">
-  {% for sheet in sheets %}
-    <div class="selectable">
-      {% if sheet.data.rows == null %}
-      <div class="govuk-body">
-        Sheet '{{ sheet.name }}' is empty
-        </div>
-      {% else %}
-        <div  class="govuk-hint">
-          First {{sheet.data.rows | length}} rows of '{{sheet.name}}'
-        </div>
-        {{ importerTableView(sheet.data, hideHeader=true) }}
-      {% endif %}
     </div>
-  {% endfor %}
-</div>
 
-<script>
-const previews = Array.from(document.getElementById("previews").children);
-
-const preview = (elem) => {
-  let index = parseInt(elem.dataset.previewIndex ?? -1);
-  if (index < 0) {
-    return;
-  }
-
-  previews.forEach((p) => {p.style.display = "none"});
-  previews[index].style.display = "block";
-}
-
-{# Show the preview any default selected options when the page loads #}
-const currentlySelected = document.querySelector('input[type="radio"]:checked');
-preview(currentlySelected);
-
-</script>
+    <div class="rd-sheet-selector-previews">
+      {% for sheet in sheets %}
+        <div class="hidden">
+          {% if sheet.data.rows == null %}
+          <div class="govuk-body">
+            Sheet '{{ sheet.name }}' is empty
+            </div>
+          {% else %}
+            {% set caption %}First {{sheet.data.rows | length}} rows of '{{sheet.name}}'{% endset %}
+            {{ importerTableView(sheet.data, hideHeader=true, caption=caption) }}
+          {% endif %}
+        </div>
+      {% endfor %}
+    </div>
+  </div>
 {% endmacro %}

--- a/lib/importer/nunjucks/importer/macros/table_view.njk
+++ b/lib/importer/nunjucks/importer/macros/table_view.njk
@@ -1,12 +1,15 @@
 
 
-{% macro importerTableView(data, hideHeader=false) %}
+{% macro importerTableView(data, hideHeader=false, caption=false) %}
     {% set headers = data.headers %}
     {% set rows = data.rows %}
     {% set moreRowsAvailable = data.extraRecordCount > 0 %}
     {% set moreRowsCount = data.extraRecordCount %}
 
     <table class="selectable govuk-body" data-persist-selection="true">
+        {% if caption %}
+        <caption class="govuk-hint">{{caption}}</caption>
+        {% endif %}
         {% if not hideHeader %}
         <thead>
             <tr>


### PR DESCRIPTION
- Use a `<caption>` element which more accurately describes the table content for screen readers
- Use CSS `visibility` instead of `display` to control which sheet is shown which means invisible sheets continue to occupy screen space, so the below elements don't move around on the screen when the selection is changed, which is difficult for people with certain cognitive issues
- Use `aria-hidden` attributes to hide invisible sheets from screen readers
- Move CSS/JS into separate files for easier reuse in the docs

WDYT @rossjones ?