### PR TITLE
Add a footer selection step

### DIFF
--- a/lib/importer/backend.js
+++ b/lib/importer/backend.js
@@ -8,6 +8,7 @@ const assert = require('node:assert').strict;
 
 let sessionStore = new Map();
 let jobStore = new Map();
+let dimensionsCache = new Map();
 
 // Maximum number of rows/records to return in one go. While we're all
 // in-memory, this merely restricts how much we allocate in one go for a shallow
@@ -53,11 +54,15 @@ function getDimensions(sid) {
   let session = sessionStore.get(sid);
   let sheetDimensions = new Map();
 
+  let cached = dimensionsCache.get(sid);
+  if (cached) {
+    return cached
+  }
+
   Object.keys(session.wb.Sheets).forEach((sheetName) => {
     const sheet = session.wb.Sheets[sheetName];
     if(sheet["!ref"]) {
       const range = xlsx.utils.decode_range(sheet["!ref"]);
-
       // The sheet may contain trailing stub rows, these are rows
       // where every cell is a stub, e.g. it contains styles but
       // no actual data. We iterate through the rows in reverse
@@ -65,7 +70,7 @@ function getDimensions(sid) {
       // many rows off the range.
       let trailingStubRows = 0;
       const data =  sheet["!data"];
-      
+
       for ( i = range.e.r; i >= 0; i--) {
         if (!data[i].every((c)=>c.t == 'z')) {
           break
@@ -85,6 +90,9 @@ function getDimensions(sid) {
       });
     }
   });
+
+  dimensionsCache.set(sid, {sheetDimensions: sheetDimensions})
+
   return {
     sheetDimensions: sheetDimensions,
   };
@@ -423,6 +431,7 @@ exports.SessionDelete = (sid) => {
     jobStore.delete(jid);
   });
   sessionStore.delete(sid);
+  dimensionsCache.delete(sid);
 }
 
 class JobResult {

--- a/lib/importer/backend.js
+++ b/lib/importer/backend.js
@@ -181,7 +181,7 @@ exports.SessionSuggestDataRange = (sid, headerRange, footerRange) => {
           column: headerRange.start.column
         },
         end: {
-          row: footerRange.start.row-1,
+          row: footerRange.start.row,
           column: headerRange.end.column
         }
       };

--- a/lib/importer/govuk-prototype-kit.config.json
+++ b/lib/importer/govuk-prototype-kit.config.json
@@ -71,6 +71,10 @@
       "importFrom": "importer/macros/table_view.njk"
     },
     {
+      "macroName": "importerHeaderSelector",
+      "importFrom": "importer/macros/header_selector.njk"
+    },
+    {
       "macroName": "importerRangeSelector",
       "importFrom": "importer/macros/range_selector.njk"
     }

--- a/lib/importer/govuk-prototype-kit.config.json
+++ b/lib/importer/govuk-prototype-kit.config.json
@@ -75,6 +75,10 @@
       "importFrom": "importer/macros/header_selector.njk"
     },
     {
+      "macroName": "importerFooterSelector",
+      "importFrom": "importer/macros/footer_selector.njk"
+    },
+    {
       "macroName": "importerRangeSelector",
       "importFrom": "importer/macros/range_selector.njk"
     }

--- a/lib/importer/index.js
+++ b/lib/importer/index.js
@@ -123,7 +123,7 @@ exports.Initialise = (config, router, prototypeKit) => {
     } else {
       response.data = header_names.map((elem, index, _arr) => {
         let examples = sheets_lib.GetColumnValues(session, index, cellWidth=20, count=5).inputValues
-        let exampleString = examples.join(", ").trim().slice(0, -1);
+        let exampleString = examples.join(", ").trim();
 
         return {
           index: index,

--- a/lib/importer/index.js
+++ b/lib/importer/index.js
@@ -21,7 +21,8 @@ const IMPORTER_ROUTE_MAP = new Map([
   ["importerSelectSheetPath", "/importer/sheets"],
   ["importerMapDataPath", "/importer/mapping"],
   ["importerReviewDataPath","/importer/review"],
-  ["importerSelectHeaderPath", "/importer/header_selection"]
+  ["importerSelectHeaderPath", "/importer/header_selection"],
+  ["importerSelectFooterPath", "/importer/footer_selection"]
 ]);
 
 exports.Initialise = (config, router, prototypeKit) => {
@@ -267,6 +268,25 @@ exports.Initialise = (config, router, prototypeKit) => {
     redirectOnwards(request, response);
   });
 
+
+  //--------------------------------------------------------------------
+  // Allows the user to optionally select a footer row should the data
+  // contain one
+  //--------------------------------------------------------------------
+  router.post(IMPORTER_ROUTE_MAP.get("importerSelectFooterPath"), (request, response) => {
+    let session = request.session.data[IMPORTER_SESSION_KEY];
+    if (!session) {
+      response.status(404);
+      return;
+    }
+
+    // WIP: Do nothing yet
+
+
+    // Ensure the session is persisted. Currently in session, eventually another way
+    request.session.data[IMPORTER_SESSION_KEY] = session;
+    redirectOnwards(request, response);
+  });
 
   //--------------------------------------------------------------------
   // Sets the mapping that the user has selected for this session.  It

--- a/lib/importer/index.js
+++ b/lib/importer/index.js
@@ -84,20 +84,23 @@ exports.Initialise = (config, router, prototypeKit) => {
     return false;
   }, {})
 
+  //--------------------------------------------------------------------
+  // Allows a template to obtain `count` rows from the start of the data
+  // range.
+  //--------------------------------------------------------------------
   prototypeKit.views.addFunction("importerGetRows", (data, count) => {
     const session = data[IMPORTER_SESSION_KEY];
     return sheets_lib.GetRows(session, count)
   }, {});
 
+  //--------------------------------------------------------------------
+  // Allows a template to obtain `count` rows from the end of the data
+  // range.
+  //--------------------------------------------------------------------
   prototypeKit.views.addFunction("importerGetTrailingRows", (data, count) => {
     const session = data[IMPORTER_SESSION_KEY];
-    let x =  sheets_lib.GetTrailingRows(session, count)
-    console.log(count)
-    console.log(x)
-
-    return x
+    return sheets_lib.GetTrailingRows(session, count)
   }, {});
-
 
 
   //--------------------------------------------------------------------
@@ -252,27 +255,7 @@ exports.Initialise = (config, router, prototypeKit) => {
     let maxCol = sheets_lib.GetTotalColumns(session);
 
     // Find the selected range, or default to the first row (0,0)->(0,maxCol)
-    // We should probably find a better way of handling no selection, and we still
-    // need to decide how users can decide between auto-choose header and user-chosen
-    // headers.
-    let tlRow = getIntOrDefault(request.body['importer:selection:TLRow']);
-    let tlCol = getIntOrDefault(request.body['importer:selection:TLCol']);
-    let brRow = getIntOrDefault(request.body['importer:selection:BRRow']);
-    let brCol = getIntOrDefault(request.body['importer:selection:BRCol'], maxCol);
-
-    // Normalise the selection so that start row <= end row and start col <= end col
-    if (tlRow > brRow) {
-      [tlRow, brRow] = [brRow, tlRow];
-    }
-    if (tlCol > brCol) {
-      [tlCol, brCol] = [brCol, tlCol];
-    }
-
-    session.headerRange = {
-      sheet: session.sheet,
-      start: {row: parseInt(tlRow), column: parseInt(tlCol)},
-      end: {row: parseInt(brRow), column: parseInt(brCol)},
-    };
+    session.headerRange = getSelectionFromRequest(request, session, optional=false);
 
     // Ensure the session is persisted. Currently in session, eventually another way
     request.session.data[IMPORTER_SESSION_KEY] = session;
@@ -291,7 +274,13 @@ exports.Initialise = (config, router, prototypeKit) => {
       return;
     }
 
-    // WIP: Do nothing yet
+    let range = getSelectionFromRequest(request, session, optional=true);
+    if (!range) {
+      redirectOnwards(request, response);
+      return;
+    }
+
+    session.footerRange = range;
 
     // Ensure the session is persisted. Currently in session, eventually another way
     request.session.data[IMPORTER_SESSION_KEY] = session;
@@ -374,4 +363,38 @@ const getIntOrDefault = (key, dflt=0) => {
     return parseInt(key)
   }
   return dflt;
+};
+
+// Given a POST request from the client, we will look for the cell range for
+// any potential selection. If we are not-optional, it will return a range
+// (which might be the default). If we are optional but can't find values
+// then we will return no range.
+const getSelectionFromRequest = (request, session, optional=false) => {
+  let defaultVal = optional ? -1 : 0;
+  let defaultMaxCol = optional ? -1 : sheets_lib.GetTotalColumns(session);
+
+  let tlRow = getIntOrDefault(request.body['importer:selection:TLRow'], defaultVal);
+  let tlCol = getIntOrDefault(request.body['importer:selection:TLCol'], defaultVal);
+  let brRow = getIntOrDefault(request.body['importer:selection:BRRow'], defaultVal);
+  let brCol = getIntOrDefault(request.body['importer:selection:BRCol'], defaultVal);
+
+  // If optional is set to true and we don't have any valid values, we will bail
+  // early
+  if (optional && [tlRow, tlCol, brRow, brCol].filter((x) => x >= 0).length < 4) {
+    return null;
+  }
+
+  // Normalise the rows
+  if (tlRow > brRow) {
+    [tlRow, brRow] = [brRow, tlRow];
+  }
+  if (tlCol > brCol) {
+    [tlCol, brCol] = [brCol, tlCol];
+  }
+
+  return {
+    sheet: session.sheet,
+    start: {row: tlRow, column: tlCol},
+    end: {row: brRow, column: brCol},
+  };
 };

--- a/lib/importer/index.js
+++ b/lib/importer/index.js
@@ -84,10 +84,21 @@ exports.Initialise = (config, router, prototypeKit) => {
     return false;
   }, {})
 
-  prototypeKit.views.addFunction("importerGetRows", (data, start, count) => {
+  prototypeKit.views.addFunction("importerGetRows", (data, count) => {
     const session = data[IMPORTER_SESSION_KEY];
-    return sheets_lib.GetRows(session, start, count)
+    return sheets_lib.GetRows(session, count)
   }, {});
+
+  prototypeKit.views.addFunction("importerGetTrailingRows", (data, count) => {
+    const session = data[IMPORTER_SESSION_KEY];
+    let x =  sheets_lib.GetTrailingRows(session, count)
+    console.log(count)
+    console.log(x)
+
+    return x
+  }, {});
+
+
 
   //--------------------------------------------------------------------
   // In the absence of a step to choose headers, we will instead provide
@@ -281,7 +292,6 @@ exports.Initialise = (config, router, prototypeKit) => {
     }
 
     // WIP: Do nothing yet
-
 
     // Ensure the session is persisted. Currently in session, eventually another way
     request.session.data[IMPORTER_SESSION_KEY] = session;

--- a/lib/importer/index.js
+++ b/lib/importer/index.js
@@ -122,7 +122,7 @@ exports.Initialise = (config, router, prototypeKit) => {
     // and footerRange with the same row index, then that means there
     // is no data and so add an error and go back.
     if (session.footerRange) {
-      if (session.headerRange.end.row >= session.footerRange.start.row -1) {
+      if (session.headerRange.end.row >= session.footerRange.start.row ) {
         // TODO: Showing an error may not be the correct thing here, can we catch
         // the error earlier?
         response.error = {text: "There is no data in this sheet"}

--- a/lib/importer/index.js
+++ b/lib/importer/index.js
@@ -118,10 +118,24 @@ exports.Initialise = (config, router, prototypeKit) => {
       error: false
     }
 
+    // Check that there is even data to map. If we have a headerRange
+    // and footerRange with the same row index, then that means there
+    // is no data and so add an error and go back.
+    if (session.footerRange) {
+      if (session.headerRange.end.row >= session.footerRange.start.row -1) {
+        // TODO: Showing an error may not be the correct thing here, can we catch
+        // the error earlier?
+        response.error = {text: "There is no data in this sheet"}
+        return response
+      }
+    }
+
+
     if (!header_names || header_names.length == 0) {
       response.error = {text: "Unable to detect header rows"}
     } else {
       response.data = header_names.map((elem, index, _arr) => {
+
         let examples = sheets_lib.GetColumnValues(session, index, cellWidth=20, count=5).inputValues
         let exampleString = examples.join(", ").trim();
 
@@ -274,13 +288,19 @@ exports.Initialise = (config, router, prototypeKit) => {
       return;
     }
 
-    let range = getSelectionFromRequest(request, session, optional=true);
-    if (!range) {
+    let selectionRange = getSelectionFromRequest(request, session, optional=true);
+    if (!selectionRange) {
       redirectOnwards(request, response);
       return;
     }
 
-    session.footerRange = range;
+    // We will assume we asked for the default of 10 rows, and calculate the offset
+    // we need to apply to the selection range so that it is valid
+    let previewRange = sheets_lib.GetRowRangeFromEnd(session, 10)
+    selectionRange.start.row += previewRange.start.row -1
+    selectionRange.end.row += previewRange.start.row -1
+
+    session.footerRange = selectionRange;
 
     // Ensure the session is persisted. Currently in session, eventually another way
     request.session.data[IMPORTER_SESSION_KEY] = session;

--- a/lib/importer/index.js
+++ b/lib/importer/index.js
@@ -88,9 +88,9 @@ exports.Initialise = (config, router, prototypeKit) => {
   // Allows a template to obtain `count` rows from the start of the data
   // range.
   //--------------------------------------------------------------------
-  prototypeKit.views.addFunction("importerGetRows", (data, count) => {
+  prototypeKit.views.addFunction("importerGetRows", (data, start, count) => {
     const session = data[IMPORTER_SESSION_KEY];
-    return sheets_lib.GetRows(session, count)
+    return sheets_lib.GetRows(session, start, count)
   }, {});
 
   //--------------------------------------------------------------------

--- a/lib/importer/nunjucks/importer/macros/footer_selector.njk
+++ b/lib/importer/nunjucks/importer/macros/footer_selector.njk
@@ -1,0 +1,8 @@
+
+{% from "importer/macros/range_selector.njk" import importerRangeSelector %}
+
+{% macro importerFooterSelector(data, start=0, end=10) %}
+    {% set rows = importerGetRows(data, start, end) %}
+
+    {{ importerRangeSelector(rows) }}
+{% endmacro %}

--- a/lib/importer/nunjucks/importer/macros/footer_selector.njk
+++ b/lib/importer/nunjucks/importer/macros/footer_selector.njk
@@ -1,8 +1,8 @@
 
 {% from "importer/macros/range_selector.njk" import importerRangeSelector %}
 
-{% macro importerFooterSelector(data, start=0, end=10) %}
-    {% set rows = importerGetRows(data, start, end) %}
+{% macro importerFooterSelector(data, count=10) %}
+    {% set rows = importerGetTrailingRows(data, count) %}
 
     {{ importerRangeSelector(rows) }}
 {% endmacro %}

--- a/lib/importer/nunjucks/importer/macros/header_selector.njk
+++ b/lib/importer/nunjucks/importer/macros/header_selector.njk
@@ -1,8 +1,8 @@
 
 {% from "importer/macros/range_selector.njk" import importerRangeSelector %}
 
-{% macro importerHeaderSelector(data, count=10) %}
-    {% set rows = importerGetRows(data, count) %}
+{% macro importerHeaderSelector(data, start, count=10) %}
+    {% set rows = importerGetRows(data, start, count) %}
 
     {{ importerRangeSelector(rows) }}
 {% endmacro %}

--- a/lib/importer/nunjucks/importer/macros/header_selector.njk
+++ b/lib/importer/nunjucks/importer/macros/header_selector.njk
@@ -1,8 +1,8 @@
 
 {% from "importer/macros/range_selector.njk" import importerRangeSelector %}
 
-{% macro importerHeaderSelector(data, start=0, end=10) %}
-    {% set rows = importerGetRows(data, start, end) %}
+{% macro importerHeaderSelector(data, count=10) %}
+    {% set rows = importerGetRows(data, count) %}
 
     {{ importerRangeSelector(rows) }}
 {% endmacro %}

--- a/lib/importer/nunjucks/importer/macros/header_selector.njk
+++ b/lib/importer/nunjucks/importer/macros/header_selector.njk
@@ -1,0 +1,8 @@
+
+{% from "importer/macros/range_selector.njk" import importerRangeSelector %}
+
+{% macro importerHeaderSelector(data, start=0, end=10) %}
+    {% set rows = importerGetRows(data, start, end) %}
+
+    {{ importerRangeSelector(rows) }}
+{% endmacro %}

--- a/lib/importer/nunjucks/importer/macros/range_selector.njk
+++ b/lib/importer/nunjucks/importer/macros/range_selector.njk
@@ -1,6 +1,5 @@
 
-{% macro importerRangeSelector(data, start=0, end=10) %}
-    {% set rows = importerGetRows(data, start, end) %}
+{% macro importerRangeSelector(rows, start=0, end=10) %}
 
 <div>
     <input type="hidden" name="importer:selection:TLRow" id="importer:selection:TLRow"/>

--- a/lib/importer/nunjucks/importer/macros/range_selector.njk
+++ b/lib/importer/nunjucks/importer/macros/range_selector.njk
@@ -1,5 +1,5 @@
 
-{% macro importerRangeSelector(rows, start=0, end=10) %}
+{% macro importerRangeSelector(rows) %}
 
 <div>
     <input type="hidden" name="importer:selection:TLRow" id="importer:selection:TLRow"/>

--- a/lib/importer/session.js
+++ b/lib/importer/session.js
@@ -12,6 +12,7 @@ class Session {
     this.sheet = "";
     this.sheets = [];
     this.headerRange = {};
+    this.footerRange = {};
     this.mapping = {};
   }
 }

--- a/lib/importer/session.js
+++ b/lib/importer/session.js
@@ -12,7 +12,7 @@ class Session {
     this.sheet = "";
     this.sheets = [];
     this.headerRange = {};
-    this.footerRange = {};
+    this.footerRange = null;
     this.mapping = {};
   }
 }

--- a/lib/importer/sheets.js
+++ b/lib/importer/sheets.js
@@ -217,13 +217,8 @@ exports.MapData = (session, previewLimit = DEFAULT_PREVIEW_LIMIT) => {
   const sheetDimensions = backend.SessionGetInputDimensions(session.backendSid)
         .sheetDimensions.get(session.sheet);
 
-<<<<<<< HEAD
   const hRange = session.headerRange;
-  const rowRange = backend.SessionSuggestDataRange(session.backendSid, session.headerRange, null);
-=======
-    const hRange = session.headerRange;
-    const rowRange = backend.SessionSuggestDataRange(session.backendSid, session.headerRange, session.footerRange);
->>>>>>> 980c7b6 (Use footer range when asking for data)
+  const rowRange = backend.SessionSuggestDataRange(session.backendSid, session.headerRange, session.footerRange);
 
   // Convert session.mapping (a map from column index -> attribute name) into a mapping for the backend
   const mappingSettings = session.mapping;

--- a/lib/importer/sheets.js
+++ b/lib/importer/sheets.js
@@ -22,7 +22,7 @@ function processMergedCells(wantedColumns, preview) {
   // FIXME: Disable colspan/rowspan generation for now, until
   // selectable_table.js is able to correctly handle selections across them.
   const disableSpans = true;
-  
+
   // Pre-process colspan/rowspan attributes in cells, so the nunjucks macro
   // that makes an HTML table doesn't need to do clever things
 
@@ -144,10 +144,10 @@ exports.GetTotalColumns = (session) => {
 };
 
 
-// Given a session and a starting row, returns up to count rows.
-exports.GetRows = (session, start=0, count=10) => {
-  const sheetDimensions = backend.SessionGetInputDimensions(session.backendSid)
-        .sheetDimensions.get(session.sheet);
+// Given a session returns up to count rows.
+exports.GetRows = (session, count=10) => {
+    const sheetDimensions = backend.SessionGetInputDimensions(session.backendSid)
+          .sheetDimensions.get(session.sheet);
 
   // Try to provide rows from start to start+count-1, but limit ourselves to
   // the rows in the sheet.
@@ -159,6 +159,25 @@ exports.GetRows = (session, start=0, count=10) => {
 
   const preview = backend.SessionGetInputSampleRows(session.backendSid, rowRange, count, 0, 0)[0];
   return processMergedCells(rowRange.end.column - rowRange.start.column + 1, preview);
+};
+
+// Given a session returns up to count rows.
+exports.GetTrailingRows = (session, count=10) => {
+    const sheetDimensions = backend.SessionGetInputDimensions(session.backendSid)
+          .sheetDimensions.get(session.sheet);
+
+    // We have to calculate the range containing the data based on what we believe
+    // the header range to be.
+    const hRange = session.headerRange;
+
+
+    const rowRange = {
+        sheet: session.sheet,
+        start: { row: hRange.end.row, column: hRange.start.column},
+        end: { row: sheetDimensions.rows, column: hRange.end.column}
+    }
+
+    return backend.SessionGetInputSampleRows(session.backendSid, rowRange, 0, 0, count)[2];
 };
 
 

--- a/lib/importer/sheets.js
+++ b/lib/importer/sheets.js
@@ -181,6 +181,8 @@ exports.GetTrailingRows = (session, count=10) => {
 };
 
 
+// Retrieves 'count' items from the column at columnIndex.  Each item be
+// shorter than `cellWidth` otherwise it will be truncated.
 exports.GetColumnValues = (session, columnIndex, cellWidth=30, count=10) => {
   let dataRange = backend.SessionSuggestDataRange(session.backendSid, session.headerRange, null);
 
@@ -206,12 +208,6 @@ exports.GetColumnValues = (session, columnIndex, cellWidth=30, count=10) => {
 
   return values;
 };
-// Return the unique values in each column in the range. Return no more than
-// maxValues values for any given column. Return format is an array, one entry
-// per column, whose entries have a .values property that's an array of values
-// and a .hasMore property that's a boolean set if the values array was
-// truncated to maxValues.
-// exports.SessionGetInputValues = (sid, range, maxValues) => {
 
 
 // Uses the session provided, which must contain a sheet name and a

--- a/lib/importer/sheets.js
+++ b/lib/importer/sheets.js
@@ -131,7 +131,7 @@ exports.GetPreview = (session, sheet) => {
     return null;
   }
 
-  return processMergedCells(dimensions.columns, preview);
+  return processMergedCells(Math.min(10, dimensions.rows), preview);
 };
 
 
@@ -157,7 +157,7 @@ exports.GetRows = (session, count=10) => {
     end: { row: Math.min(start + count - 1, sheetDimensions.rows-1), column: sheetDimensions.columns-1}
   }
 
-  const preview = backend.SessionGetInputSampleRows(session.backendSid, rowRange, count, 0, 0)[0];
+  const preview = backend.SessionGetInputSampleRows(session.backendSid, rowRange, Math.min(count, sheetDimensions.rows), 0, 0)[0];
   return processMergedCells(rowRange.end.column - rowRange.start.column + 1, preview);
 };
 
@@ -170,14 +170,13 @@ exports.GetTrailingRows = (session, count=10) => {
     // the header range to be.
     const hRange = session.headerRange;
 
-
     const rowRange = {
         sheet: session.sheet,
         start: { row: hRange.end.row, column: hRange.start.column},
-        end: { row: sheetDimensions.rows, column: hRange.end.column}
+        end: { row: sheetDimensions.rows -1, column: hRange.end.column}
     }
 
-    return backend.SessionGetInputSampleRows(session.backendSid, rowRange, 0, 0, count)[2];
+    return backend.SessionGetInputSampleRows(session.backendSid, rowRange, 0, 0, Math.min(count, sheetDimensions.rows))[2];
 };
 
 

--- a/lib/importer/sheets.js
+++ b/lib/importer/sheets.js
@@ -183,7 +183,7 @@ exports.GetTrailingRows = (session, count=10) => {
 // Retrieves 'count' items from the column at columnIndex.  Each item be
 // shorter than `cellWidth` otherwise it will be truncated.
 exports.GetColumnValues = (session, columnIndex, cellWidth=30, count=10) => {
-  let dataRange = backend.SessionSuggestDataRange(session.backendSid, session.headerRange, null);
+  let dataRange = backend.SessionSuggestDataRange(session.backendSid, session.headerRange, session.footerRange);
 
   // Limit to just the column we want
   dataRange.start.column += columnIndex;
@@ -217,8 +217,13 @@ exports.MapData = (session, previewLimit = DEFAULT_PREVIEW_LIMIT) => {
   const sheetDimensions = backend.SessionGetInputDimensions(session.backendSid)
         .sheetDimensions.get(session.sheet);
 
+<<<<<<< HEAD
   const hRange = session.headerRange;
   const rowRange = backend.SessionSuggestDataRange(session.backendSid, session.headerRange, null);
+=======
+    const hRange = session.headerRange;
+    const rowRange = backend.SessionSuggestDataRange(session.backendSid, session.headerRange, session.footerRange);
+>>>>>>> 980c7b6 (Use footer range when asking for data)
 
   // Convert session.mapping (a map from column index -> attribute name) into a mapping for the backend
   const mappingSettings = session.mapping;

--- a/lib/importer/sheets.js
+++ b/lib/importer/sheets.js
@@ -145,7 +145,7 @@ exports.GetTotalColumns = (session) => {
 
 
 // Given a session returns up to count rows.
-exports.GetRows = (session, count=10) => {
+exports.GetRows = (session, start=0, count=10) => {
     const sheetDimensions = backend.SessionGetInputDimensions(session.backendSid)
           .sheetDimensions.get(session.sheet);
 
@@ -157,7 +157,7 @@ exports.GetRows = (session, count=10) => {
     end: { row: Math.min(start + count - 1, sheetDimensions.rows-1), column: sheetDimensions.columns-1}
   }
 
-  const wantedRows = rowRange.end.row - hRange.end.row;
+  const wantedRows = rowRange.end.row - start;
   const preview = backend.SessionGetInputSampleRows(session.backendSid, rowRange, wantedRows, 0, 0)[0];
   return processMergedCells(rowRange.end.column - rowRange.start.column + 1, preview);
 };

--- a/lib/importer/sheets.js
+++ b/lib/importer/sheets.js
@@ -162,22 +162,26 @@ exports.GetRows = (session, start=0, count=10) => {
   return processMergedCells(rowRange.end.column - rowRange.start.column + 1, preview);
 };
 
+exports.GetRowRangeFromEnd = (session, count=10) => {
+  const sheetDimensions = backend.SessionGetInputDimensions(session.backendSid)
+  .sheetDimensions.get(session.sheet);
+
+  // We have to calculate the range containing the data based on what we believe
+  // the header range to be.
+  const hRange = session.headerRange;
+
+  const end = sheetDimensions.rows -1;
+  return {
+    sheet: session.sheet,
+    start: { row: Math.max(end-count, hRange.start.row +1), column: hRange.start.column},
+    end: { row: end, column: hRange.end.column}
+  }
+}
+
 // Given a session returns up to count rows.
 exports.GetTrailingRows = (session, count=10) => {
-    const sheetDimensions = backend.SessionGetInputDimensions(session.backendSid)
-          .sheetDimensions.get(session.sheet);
-
-    // We have to calculate the range containing the data based on what we believe
-    // the header range to be.
     const hRange = session.headerRange;
-
-    const end = sheetDimensions.rows -1;
-    const rowRange = {
-        sheet: session.sheet,
-        start: { row: Math.max(end-count, hRange.start.row +1), column: hRange.start.column},
-        end: { row: end, column: hRange.end.column}
-    }
-
+    const rowRange = exports.GetRowRangeFromEnd(session, count)
     const wantedRows = Math.min(count, rowRange.end.row - hRange.end.row);
     return backend.SessionGetInputSampleRows(session.backendSid, rowRange, 0, 0, wantedRows)[2];
 };
@@ -187,7 +191,6 @@ exports.GetTrailingRows = (session, count=10) => {
 // shorter than `cellWidth` otherwise it will be truncated.
 exports.GetColumnValues = (session, columnIndex, cellWidth=30, count=10) => {
   let dataRange = backend.SessionSuggestDataRange(session.backendSid, session.headerRange, session.footerRange);
-
   // Limit to just the column we want
   dataRange.start.column += columnIndex;
   dataRange.end.column = dataRange.start.column;

--- a/lib/importer/sheets.js
+++ b/lib/importer/sheets.js
@@ -106,7 +106,7 @@ function processMergedCells(wantedColumns, preview) {
 // Given a session and a sheet name, gets a preview of the data held there
 // returning either a 2dim array of rows/cells or null if that specific sheet
 // is empty.
-exports.GetPreview = (session, sheet) => {
+exports.GetPreview = (session, sheet, count=10) => {
   const dimensions = backend
         .SessionGetInputDimensions(session.backendSid)
         .sheetDimensions.get(sheet);
@@ -115,7 +115,7 @@ exports.GetPreview = (session, sheet) => {
     sheet: sheet,
     start: {row: 0, column: 0},
     end: {row: dimensions.rows, column: dimensions.columns > 0 ? dimensions.columns - 1 : 0 }
-  }, Math.min(10, dimensions.rows), 0, 0)[0];
+  }, Math.min(count, dimensions.rows), 0, 0)[0];
 
   // TODO: Is there a better way to tell if the sheet is empty than iterating
   // all the cells? - we should have something in SessionGetInputDimensions
@@ -131,7 +131,7 @@ exports.GetPreview = (session, sheet) => {
     return null;
   }
 
-  return processMergedCells(Math.min(10, dimensions.rows), preview);
+  return processMergedCells(dimensions.columns, preview);
 };
 
 

--- a/lib/importer/sheets.js
+++ b/lib/importer/sheets.js
@@ -171,13 +171,14 @@ exports.GetTrailingRows = (session, count=10) => {
     // the header range to be.
     const hRange = session.headerRange;
 
+    const end = sheetDimensions.rows -1;
     const rowRange = {
         sheet: session.sheet,
-        start: { row: hRange.end.row, column: hRange.start.column},
-        end: { row: sheetDimensions.rows -1, column: hRange.end.column}
+        start: { row: Math.max(end-count, hRange.start.row +1), column: hRange.start.column},
+        end: { row: end, column: hRange.end.column}
     }
 
-    const wantedRows = rowRange.end.row - hRange.end.row;
+    const wantedRows = Math.min(count, rowRange.end.row - hRange.end.row);
     return backend.SessionGetInputSampleRows(session.backendSid, rowRange, 0, 0, wantedRows)[2];
 };
 

--- a/lib/importer/sheets.js
+++ b/lib/importer/sheets.js
@@ -115,7 +115,7 @@ exports.GetPreview = (session, sheet) => {
     sheet: sheet,
     start: {row: 0, column: 0},
     end: {row: dimensions.rows, column: dimensions.columns > 0 ? dimensions.columns - 1 : 0 }
-  }, 10, 0, 0)[0];
+  }, Math.min(10, dimensions.rows), 0, 0)[0];
 
   // TODO: Is there a better way to tell if the sheet is empty than iterating
   // all the cells? - we should have something in SessionGetInputDimensions
@@ -157,7 +157,8 @@ exports.GetRows = (session, count=10) => {
     end: { row: Math.min(start + count - 1, sheetDimensions.rows-1), column: sheetDimensions.columns-1}
   }
 
-  const preview = backend.SessionGetInputSampleRows(session.backendSid, rowRange, Math.min(count, sheetDimensions.rows), 0, 0)[0];
+  const wantedRows = rowRange.end.row - hRange.end.row;
+  const preview = backend.SessionGetInputSampleRows(session.backendSid, rowRange, wantedRows, 0, 0)[0];
   return processMergedCells(rowRange.end.column - rowRange.start.column + 1, preview);
 };
 
@@ -176,7 +177,8 @@ exports.GetTrailingRows = (session, count=10) => {
         end: { row: sheetDimensions.rows -1, column: hRange.end.column}
     }
 
-    return backend.SessionGetInputSampleRows(session.backendSid, rowRange, 0, 0, Math.min(count, sheetDimensions.rows))[2];
+    const wantedRows = rowRange.end.row - hRange.end.row;
+    return backend.SessionGetInputSampleRows(session.backendSid, rowRange, 0, 0, wantedRows)[2];
 };
 
 

--- a/lib/importer/templates/mapping.html
+++ b/lib/importer/templates/mapping.html
@@ -1,6 +1,6 @@
 {% extends "layouts/main.html" %}
 
-{% block pageTitle %} – {{ serviceName }} – GOV.UK Prototype Kit {% endblock %}
+{% block pageTitle %} {{ serviceName }} – GOV.UK Prototype Kit {% endblock %}
 {% block beforeContent %}
 {{ govukBackLink({ text: "Back", href: "javascript:window.history.back()" }) }}
 {% endblock %}

--- a/lib/importer/templates/review.html
+++ b/lib/importer/templates/review.html
@@ -2,7 +2,7 @@
 {% from "importer/macros/table_view.njk" import importerTableView %}
 
 
-{% block pageTitle %} – {{ serviceName }} – GOV.UK Prototype Kit {% endblock %}
+{% block pageTitle %} {{ serviceName }} – GOV.UK Prototype Kit {% endblock %}
 {% block beforeContent %}
 {{ govukBackLink({ text: "Back", href: "javascript:window.history.back()" }) }}
 {% endblock %}

--- a/lib/importer/templates/select_footer_row.html
+++ b/lib/importer/templates/select_footer_row.html
@@ -4,7 +4,7 @@
 {{ super() }}
 {% endblock %}
 
-{% block pageTitle %} – {{ serviceName }} – GOV.UK Prototype Kit {% endblock %}
+{% block pageTitle %} {{ serviceName }} – GOV.UK Prototype Kit {% endblock %}
 
 {% block beforeContent %}
 {{ govukBackLink({ text: "Back", href: "javascript:window.history.back()" }) }}

--- a/lib/importer/templates/select_footer_row.html
+++ b/lib/importer/templates/select_footer_row.html
@@ -1,19 +1,29 @@
 {% extends "layouts/main.html" %}
 
+{% block head %}
+{{ super() }}
+{% endblock %}
+
 {% block pageTitle %} – {{ serviceName }} – GOV.UK Prototype Kit {% endblock %}
 
 {% block beforeContent %}
 {{ govukBackLink({ text: "Back", href: "javascript:window.history.back()" }) }}
 {% endblock %}
 
-{% from "importer/macros/range_selector.njk" import importerRangeSelector %}
+{% from "importer/macros/footer_selector.njk" import importerFooterSelector %}
 
 {% block content %}
 <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-        <form action="{{ importerSelectSheetPath('/mapping') }}" method="post">
+    <div class="govuk-grid-column-three-quarters">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+            <h1 class="govuk-fieldset__heading">
+                Select cells containing footer data
+            </h1>
+        </legend>
+
+        <form action="{{ importerSelectFooterPath('/mapping') }}" method="post">
             <div class="govuk-form-group">
-                {{ importerRangeSelector(data) }}
+                {{ importerFooterSelector(data) }}
             </div>
 
             <div class="govuk-button-group">

--- a/lib/importer/templates/select_header_row.html
+++ b/lib/importer/templates/select_header_row.html
@@ -4,7 +4,7 @@
 {{ super() }}
 {% endblock %}
 
-{% block pageTitle %} – {{ serviceName }} – GOV.UK Prototype Kit {% endblock %}
+{% block pageTitle %} {{ serviceName }} – GOV.UK Prototype Kit {% endblock %}
 
 {% block beforeContent %}
 {{ govukBackLink({ text: "Back", href: "javascript:window.history.back()" }) }}

--- a/lib/importer/templates/select_header_row.html
+++ b/lib/importer/templates/select_header_row.html
@@ -1,19 +1,29 @@
 {% extends "layouts/main.html" %}
 
+{% block head %}
+{{ super() }}
+{% endblock %}
+
 {% block pageTitle %} – {{ serviceName }} – GOV.UK Prototype Kit {% endblock %}
 
 {% block beforeContent %}
 {{ govukBackLink({ text: "Back", href: "javascript:window.history.back()" }) }}
 {% endblock %}
 
-{% from "importer/macros/range_selector.njk" import importerRangeSelector %}
+{% from "importer/macros/header_selector.njk" import importerHeaderSelector %}
 
 {% block content %}
 <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-        <form action="{{ importerSelectSheetPath('/mapping') }}" method="post">
+    <div class="govuk-grid-column-three-quarters">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+            <h1 class="govuk-fieldset__heading">
+                Select cells containing column headings
+            </h1>
+        </legend>
+
+        <form action="{{ importerSelectHeaderPath('/select_footer_row') }}" method="post">
             <div class="govuk-form-group">
-                {{ importerRangeSelector(data) }}
+                {{ importerHeaderSelector(data, 0, 10) }}
             </div>
 
             <div class="govuk-button-group">

--- a/lib/importer/templates/select_header_row.html
+++ b/lib/importer/templates/select_header_row.html
@@ -23,7 +23,7 @@
 
         <form action="{{ importerSelectHeaderPath('/select_footer_row') }}" method="post">
             <div class="govuk-form-group">
-                {{ importerHeaderSelector(data, 10) }}
+                {{ importerHeaderSelector(data, 0, 10) }}
             </div>
 
             <div class="govuk-button-group">

--- a/lib/importer/templates/select_sheet.html
+++ b/lib/importer/templates/select_sheet.html
@@ -2,7 +2,7 @@
 
 {% from "importer/macros/sheet_selector.njk" import importerSheetSelector %}
 
-{% block pageTitle %} – {{ serviceName }} – GOV.UK Prototype Kit {% endblock %}
+{% block pageTitle %} {{ serviceName }} – GOV.UK Prototype Kit {% endblock %}
 {% block beforeContent %}
 {{ govukBackLink({ text: "Back", href: "javascript:window.history.back()" }) }}
 {% endblock %}

--- a/lib/importer/templates/success.html
+++ b/lib/importer/templates/success.html
@@ -2,7 +2,7 @@
 
 {% from "govuk/components/file-upload/macro.njk" import govukFileUpload %}
 
-{% block pageTitle %} – {{ serviceName }} – GOV.UK Prototype Kit {% endblock %}
+{% block pageTitle %} {{ serviceName }} – GOV.UK Prototype Kit {% endblock %}
 
 {% block content %}
 <div class="govuk-width-container">

--- a/lib/importer/templates/upload.html
+++ b/lib/importer/templates/upload.html
@@ -2,7 +2,7 @@
 
 {% from "govuk/components/file-upload/macro.njk" import govukFileUpload %}
 
-{% block pageTitle %} – {{ serviceName }} – GOV.UK Prototype Kit {% endblock %}
+{% block pageTitle %} {{ serviceName }} – GOV.UK Prototype Kit {% endblock %}
 {% block beforeContent %}
 {{ govukBackLink({ text: "Back", href: "javascript:window.history.back()" }) }}
 {% endblock %}
@@ -15,11 +15,11 @@
         <form action="{{importerUploadPath('/select_sheet')}}" method="POST" enctype="multipart/form-data">
             <div>
                 {{ govukFileUpload({
-                    id: "file-upload",
-                    name: "file",
-                    label: { text: "Upload an XLSX file"},
-                    attributes: { "accept": ".xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"},
-                    errorMessage: importerError(data)
+                id: "file-upload",
+                name: "file",
+                label: { text: "Upload an XLSX file"},
+                attributes: { "accept": ".xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"},
+                errorMessage: importerError(data)
                 })
                 }}
             </div>

--- a/prototypes/basic/app/views/mapping.html
+++ b/prototypes/basic/app/views/mapping.html
@@ -1,6 +1,6 @@
 {% extends "layouts/main.html" %}
 
-{% block pageTitle %} – {{ serviceName }} – GOV.UK Prototype Kit {% endblock %}
+{% block pageTitle %} {{ serviceName }} – GOV.UK Prototype Kit {% endblock %}
 {% block beforeContent %}
 {{ govukBackLink({ text: "Back", href: "javascript:window.history.back()" }) }}
 {% endblock %}

--- a/prototypes/basic/app/views/review.html
+++ b/prototypes/basic/app/views/review.html
@@ -2,7 +2,7 @@
 {% from "importer/macros/table_view.njk" import importerTableView %}
 
 
-{% block pageTitle %} – {{ serviceName }} – GOV.UK Prototype Kit {% endblock %}
+{% block pageTitle %} {{ serviceName }} – GOV.UK Prototype Kit {% endblock %}
 {% block beforeContent %}
 {{ govukBackLink({ text: "Back", href: "javascript:window.history.back()" }) }}
 {% endblock %}

--- a/prototypes/basic/app/views/select_footer_row.html
+++ b/prototypes/basic/app/views/select_footer_row.html
@@ -4,7 +4,7 @@
 {{ super() }}
 {% endblock %}
 
-{% block pageTitle %} – {{ serviceName }} – GOV.UK Prototype Kit {% endblock %}
+{% block pageTitle %} {{ serviceName }} – GOV.UK Prototype Kit {% endblock %}
 
 {% block beforeContent %}
 {{ govukBackLink({ text: "Back", href: "javascript:window.history.back()" }) }}

--- a/prototypes/basic/app/views/select_footer_row.html
+++ b/prototypes/basic/app/views/select_footer_row.html
@@ -10,20 +10,20 @@
 {{ govukBackLink({ text: "Back", href: "javascript:window.history.back()" }) }}
 {% endblock %}
 
-{% from "importer/macros/header_selector.njk" import importerHeaderSelector %}
+{% from "importer/macros/footer_selector.njk" import importerFooterSelector %}
 
 {% block content %}
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
             <h1 class="govuk-fieldset__heading">
-                Select cells containing column headings
+                Select cells containing footer data
             </h1>
         </legend>
 
-        <form action="{{ importerSelectHeaderPath('/select_footer_row') }}" method="post">
+        <form action="{{ importerSelectFooterPath('/mapping') }}" method="post">
             <div class="govuk-form-group">
-                {{ importerHeaderSelector(data, 10) }}
+                {{ importerFooterSelector(data) }}
             </div>
 
             <div class="govuk-button-group">

--- a/prototypes/basic/app/views/select_footer_row.html
+++ b/prototypes/basic/app/views/select_footer_row.html
@@ -27,6 +27,7 @@
             </div>
 
             <div class="govuk-button-group">
+                {{ govukButton({ text: "Skip", classes: "govuk-button--secondary"}) }}
                 {{ govukButton({ text: "Next" }) }}
             </div>
         </form>

--- a/prototypes/basic/app/views/select_header_row.html
+++ b/prototypes/basic/app/views/select_header_row.html
@@ -10,7 +10,7 @@
 {{ govukBackLink({ text: "Back", href: "javascript:window.history.back()" }) }}
 {% endblock %}
 
-{% from "importer/macros/range_selector.njk" import importerRangeSelector %}
+{% from "importer/macros/header_selector.njk" import importerHeaderSelector %}
 
 {% block content %}
 <div class="govuk-grid-row">
@@ -23,7 +23,7 @@
 
         <form action="{{ importerSelectHeaderPath('/mapping') }}" method="post">
             <div class="govuk-form-group">
-                {{ importerRangeSelector(data, 0, 10) }}
+                {{ importerHeaderSelector(data, 0, 10) }}
             </div>
 
             <div class="govuk-button-group">

--- a/prototypes/basic/app/views/select_header_row.html
+++ b/prototypes/basic/app/views/select_header_row.html
@@ -4,7 +4,7 @@
 {{ super() }}
 {% endblock %}
 
-{% block pageTitle %} – {{ serviceName }} – GOV.UK Prototype Kit {% endblock %}
+{% block pageTitle %} {{ serviceName }} – GOV.UK Prototype Kit {% endblock %}
 
 {% block beforeContent %}
 {{ govukBackLink({ text: "Back", href: "javascript:window.history.back()" }) }}

--- a/prototypes/basic/app/views/select_header_row.html
+++ b/prototypes/basic/app/views/select_header_row.html
@@ -21,7 +21,7 @@
             </h1>
         </legend>
 
-        <form action="{{ importerSelectHeaderPath('/mapping') }}" method="post">
+        <form action="{{ importerSelectHeaderPath('/select_footer_row') }}" method="post">
             <div class="govuk-form-group">
                 {{ importerHeaderSelector(data, 0, 10) }}
             </div>

--- a/prototypes/basic/app/views/select_header_row.html
+++ b/prototypes/basic/app/views/select_header_row.html
@@ -23,7 +23,7 @@
 
         <form action="{{ importerSelectHeaderPath('/select_footer_row') }}" method="post">
             <div class="govuk-form-group">
-                {{ importerHeaderSelector(data, 0, 10) }}
+                {{ importerHeaderSelector(data, 10) }}
             </div>
 
             <div class="govuk-button-group">

--- a/prototypes/basic/app/views/select_header_row.html
+++ b/prototypes/basic/app/views/select_header_row.html
@@ -23,7 +23,7 @@
 
         <form action="{{ importerSelectHeaderPath('/select_footer_row') }}" method="post">
             <div class="govuk-form-group">
-                {{ importerHeaderSelector(data, 10) }}
+                {{ importerHeaderSelector(data, 0, 10) }}
             </div>
 
             <div class="govuk-button-group">

--- a/prototypes/basic/app/views/select_sheet.html
+++ b/prototypes/basic/app/views/select_sheet.html
@@ -2,7 +2,7 @@
 
 {% from "importer/macros/sheet_selector.njk" import importerSheetSelector %}
 
-{% block pageTitle %} – {{ serviceName }} – GOV.UK Prototype Kit {% endblock %}
+{% block pageTitle %} {{ serviceName }} – GOV.UK Prototype Kit {% endblock %}
 {% block beforeContent %}
 {{ govukBackLink({ text: "Back", href: "javascript:window.history.back()" }) }}
 {% endblock %}

--- a/prototypes/basic/app/views/success.html
+++ b/prototypes/basic/app/views/success.html
@@ -2,7 +2,7 @@
 
 {% from "govuk/components/file-upload/macro.njk" import govukFileUpload %}
 
-{% block pageTitle %} – {{ serviceName }} – GOV.UK Prototype Kit {% endblock %}
+{% block pageTitle %} {{ serviceName }} – GOV.UK Prototype Kit {% endblock %}
 
 
 {% block content %}

--- a/prototypes/basic/app/views/upload.html
+++ b/prototypes/basic/app/views/upload.html
@@ -2,7 +2,7 @@
 
 {% from "govuk/components/file-upload/macro.njk" import govukFileUpload %}
 
-{% block pageTitle %} – {{ serviceName }} – GOV.UK Prototype Kit {% endblock %}
+{% block pageTitle %} {{ serviceName }} – GOV.UK Prototype Kit {% endblock %}
 {% block beforeContent %}
 {{ govukBackLink({ text: "Back", href: "javascript:window.history.back()" }) }}
 {% endblock %}
@@ -30,5 +30,5 @@
     </div>
 </div>
 
-                        
+
 {% endblock %}


### PR DESCRIPTION
Adds an optional step after header selection for selecting any footer cells in the current sheet.  To do this the PR contains a refactor of the range selector so that users should now use `importerHeaderSelector` or `importerFooterSelector` rather than the lower-level `importerRangeSelector`; this allows us to fetch specific rows for each selector type in the outer macro, passing the rows to the inner importerRangeSelector macro.

The new footer selection step allows for no selection, either by pressing the Skip button or by not selecting any cells in the presented table.  
