### PR TITLE
Add MVP designer experience documentation

### DIFF
--- a/lib/importer/assets/docs/component-sheet-selector.html
+++ b/lib/importer/assets/docs/component-sheet-selector.html
@@ -1,0 +1,481 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <title>Sheet selector – Tabular Data Importer by Register Dynamics</title>
+    <link href="/public/stylesheets/application.css" rel="stylesheet" type="text/css" />
+    <link href="../css/sheet_selector.css" rel="stylesheet" type="text/css" />
+    <link href="../css/selectable_table.css" rel="stylesheet" type="text/css" />
+    <link href="./docs.css" rel="stylesheet" type="text/css" />
+    <style type="text/css" data-plugin-only>
+        [data-static-only] {
+            display: none;
+        }
+    </style>
+    <link data-plugin-only rel="icon" sizes="48x48"
+        href="/manage-prototype/dependencies/govuk-frontend/dist/govuk/assets/images/favicon.ico">
+    <link data-plugin-only rel="icon" sizes="any"
+        href="/manage-prototype/dependencies/govuk-frontend/dist/govuk/assets/images/favicon.svg" type="image/svg+xml">
+    <link data-plugin-only rel="mask-icon"
+        href="/manage-prototype/dependencies/govuk-frontend/dist/govuk/assets/images/govuk-icon-mask.svg"
+        color="#0b0c0c">
+    <link data-plugin-only rel="apple-touch-icon"
+        href="/manage-prototype/dependencies/govuk-frontend/dist/govuk/assets/images/govuk-icon-180.png">
+    <script src="../js/class_list.js"></script>
+    <script src="../js/keys.js"></script>
+    <script src="../js/selectable_polyfills.js"></script>
+    <script src="../js/sheet_selector.js"></script>
+    <script src="../js/selectable_table.js"></script>
+    <script src="/plugin-assets/govuk-prototype-kit/lib/assets/javascripts/kit.js"></script>
+    <script src="/plugin-assets/govuk-prototype-kit/lib/assets/javascripts/auto-store-data.js"></script>
+    <script type="module" src="/plugin-assets/govuk-frontend/dist/govuk/govuk-frontend.min.js"></script>
+    <script type="module" src="/plugin-assets/govuk-frontend/dist/govuk-prototype-kit/init.js"></script>
+    <script type="module" src="/public/javascripts/application.js"></script>
+
+</head>
+
+<body class="govuk-template__body govuk-frontend-supported">
+    <a href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+    <header class="govuk-header">
+        <div class="govuk-header__container govuk-width-container">
+            <div class="govuk-header__logo">
+                <a href="/manage-prototype" data-plugin-only class="govuk-header__link govuk-header__link--homepage">
+                    <svg focusable="false" role="img" class="govuk-header__logotype" xmlns="http://www.w3.org/2000/svg"
+                        viewBox="0 0 148 30" height="30" width="148" aria-label="GOV.UK">
+                        <title>GOV.UK</title>
+                        <path
+                            d="M22.6 10.4c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m-5.9 6.7c-.9.4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m10.8-3.7c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s0 2-1 2.4m3.3 4.8c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4M17 4.7l2.3 1.2V2.5l-2.3.7-.2-.2.9-3h-3.4l.9 3-.2.2c-.1.1-2.3-.7-2.3-.7v3.4L15 4.7c.1.1.1.2.2.2l-1.3 4c-.1.2-.1.4-.1.6 0 1.1.8 2 1.9 2.2h.7c1-.2 1.9-1.1 1.9-2.1 0-.2 0-.4-.1-.6l-1.3-4c-.1-.2 0-.2.1-.3m-7.6 5.7c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m-5 3c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s.1 2 1 2.4m-3.2 4.8c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m14.8 11c4.4 0 8.6.3 12.3.8 1.1-4.5 2.4-7 3.7-8.8l-2.5-.9c.2 1.3.3 1.9 0 2.7-.4-.4-.8-1.1-1.1-2.3l-1.2 4c.7-.5 1.3-.8 2-.9-1.1 2.5-2.6 3.1-3.5 3-1.1-.2-1.7-1.2-1.5-2.1.3-1.2 1.5-1.5 2.1-.1 1.1-2.3-.8-3-2-2.3 1.9-1.9 2.1-3.5.6-5.6-2.1 1.6-2.1 3.2-1.2 5.5-1.2-1.4-3.2-.6-2.5 1.6.9-1.4 2.1-.5 1.9.8-.2 1.1-1.7 2.1-3.5 1.9-2.7-.2-2.9-2.1-2.9-3.6.7-.1 1.9.5 2.9 1.9l.4-4.3c-1.1 1.1-2.1 1.4-3.2 1.4.4-1.2 2.1-3 2.1-3h-5.4s1.7 1.9 2.1 3c-1.1 0-2.1-.2-3.2-1.4l.4 4.3c1-1.4 2.2-2 2.9-1.9-.1 1.5-.2 3.4-2.9 3.6-1.9.2-3.4-.8-3.5-1.9-.2-1.3 1-2.2 1.9-.8.7-2.3-1.2-3-2.5-1.6.9-2.2.9-3.9-1.2-5.5-1.5 2-1.3 3.7.6 5.6-1.2-.7-3.1 0-2 2.3.6-1.4 1.8-1.1 2.1.1.2.9-.3 1.9-1.5 2.1-.9.2-2.4-.5-3.5-3 .6 0 1.2.3 2 .9l-1.2-4c-.3 1.1-.7 1.9-1.1 2.3-.3-.8-.2-1.4 0-2.7l-2.9.9C1.3 23 2.6 25.5 3.7 30c3.7-.5 7.9-.8 12.3-.8m28.3-11.6c0 .9.1 1.7.3 2.5.2.8.6 1.5 1 2.2.5.6 1 1.1 1.7 1.5.7.4 1.5.6 2.5.6.9 0 1.7-.1 2.3-.4s1.1-.7 1.5-1.1c.4-.4.6-.9.8-1.5.1-.5.2-1 .2-1.5v-.2h-5.3v-3.2h9.4V28H55v-2.5c-.3.4-.6.8-1 1.1-.4.3-.8.6-1.3.9-.5.2-1 .4-1.6.6s-1.2.2-1.8.2c-1.5 0-2.9-.3-4-.8-1.2-.6-2.2-1.3-3-2.3-.8-1-1.4-2.1-1.8-3.4-.3-1.4-.5-2.8-.5-4.3s.2-2.9.7-4.2c.5-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.6 2.6-.8 4.1-.8 1 0 1.9.1 2.8.3.9.2 1.7.6 2.4 1s1.4.9 1.9 1.5c.6.6 1 1.3 1.4 2l-3.7 2.1c-.2-.4-.5-.9-.8-1.2-.3-.4-.6-.7-1-1-.4-.3-.8-.5-1.3-.7-.5-.2-1.1-.2-1.7-.2-1 0-1.8.2-2.5.6-.7.4-1.3.9-1.7 1.5-.5.6-.8 1.4-1 2.2-.3.8-.4 1.9-.4 2.7zM71.5 6.8c1.5 0 2.9.3 4.2.8 1.2.6 2.3 1.3 3.1 2.3.9 1 1.5 2.1 2 3.4s.7 2.7.7 4.2-.2 2.9-.7 4.2c-.4 1.3-1.1 2.4-2 3.4-.9 1-1.9 1.7-3.1 2.3-1.2.6-2.6.8-4.2.8s-2.9-.3-4.2-.8c-1.2-.6-2.3-1.3-3.1-2.3-.9-1-1.5-2.1-2-3.4-.4-1.3-.7-2.7-.7-4.2s.2-2.9.7-4.2c.4-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.5 2.6-.8 4.2-.8zm0 17.6c.9 0 1.7-.2 2.4-.5s1.3-.8 1.7-1.4c.5-.6.8-1.3 1.1-2.2.2-.8.4-1.7.4-2.7v-.1c0-1-.1-1.9-.4-2.7-.2-.8-.6-1.6-1.1-2.2-.5-.6-1.1-1.1-1.7-1.4-.7-.3-1.5-.5-2.4-.5s-1.7.2-2.4.5-1.3.8-1.7 1.4c-.5.6-.8 1.3-1.1 2.2-.2.8-.4 1.7-.4 2.7v.1c0 1 .1 1.9.4 2.7.2.8.6 1.6 1.1 2.2.5.6 1.1 1.1 1.7 1.4.6.3 1.4.5 2.4.5zM88.9 28 83 7h4.7l4 15.7h.1l4-15.7h4.7l-5.9 21h-5.7zm28.8-3.6c.6 0 1.2-.1 1.7-.3.5-.2 1-.4 1.4-.8.4-.4.7-.8.9-1.4.2-.6.3-1.2.3-2v-13h4.1v13.6c0 1.2-.2 2.2-.6 3.1s-1 1.7-1.8 2.4c-.7.7-1.6 1.2-2.7 1.5-1 .4-2.2.5-3.4.5-1.2 0-2.4-.2-3.4-.5-1-.4-1.9-.9-2.7-1.5-.8-.7-1.3-1.5-1.8-2.4-.4-.9-.6-2-.6-3.1V6.9h4.2v13c0 .8.1 1.4.3 2 .2.6.5 1 .9 1.4.4.4.8.6 1.4.8.6.2 1.1.3 1.8.3zm13-17.4h4.2v9.1l7.4-9.1h5.2l-7.2 8.4L148 28h-4.9l-5.5-9.4-2.7 3V28h-4.2V7zm-27.6 16.1c-1.5 0-2.7 1.2-2.7 2.7s1.2 2.7 2.7 2.7 2.7-1.2 2.7-2.7-1.2-2.7-2.7-2.7z">
+                        </path>
+                    </svg>
+                </a>
+                <a href="/" data-static-only class="govuk-header__link govuk-header__link--homepage">Tabular Data
+                    Importer</a>
+            </div>
+            <div class="govuk-header__content">
+                <a href="/manage-prototype" data-plugin-only class="govuk-header__link govuk-header__service-name">
+                    Prototype Kit
+                </a>
+            </div>
+        </div>
+    </header>
+
+    <div class="govuk-width-container">
+        <nav class="govuk-breadcrumbs" aria-label="Breadcrumb">
+            <ol class="govuk-breadcrumbs__list">
+                <li class="govuk-breadcrumbs__list-item">
+                    <a class="govuk-breadcrumbs__link" href="./index.html">Home</a>
+                </li>
+                <li class="govuk-breadcrumbs__list-item">
+                    <span class="govuk-breadcrumbs__link">Components</a>
+                </li>
+                <li class="govuk-breadcrumbs__list-item">
+                    <a class="govuk-breadcrumbs__link" href="#">Sheet selector</a>
+                </li>
+            </ol>
+        </nav>
+
+        <main class="govuk-main-wrapper" id="main-content">
+            <span class="govuk-caption-xl">Components</span>
+            <h1 class="govuk-heading-xl">Sheet selector</h1>
+            <p>Ask the user to pick one from multiple worksheets in a spreadsheet they uploaded.</p>
+
+            <div class="example">
+                <div class="govuk-form ">
+                    <div class="govuk-form-group ">
+                        <div class="govuk-radios rd-sheet-preview" data-module="govuk-radios">
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="Export Summary" name="sheet" type="radio"
+                                    value="Commodities" data-preview-index="0" checked>
+                                <label class="govuk-label govuk-radios__label" for="Export Summary">
+                                    Commodities
+                                </label>
+                            </div> <!-- .govuk-radios__item  -->
+
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="My lovely tribbles" name="sheet" type="radio"
+                                    value="Footnotes" data-preview-index="1">
+                                <label class="govuk-label govuk-radios__label" for="My lovely tribbles">
+                                    Footnotes
+                                </label>
+                            </div> <!-- .govuk-radios__item  -->
+
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="My lovely snakes" name="sheet" type="radio"
+                                    value="Certificates" data-preview-index="2">
+                                <label class="govuk-label govuk-radios__label" for="My lovely snakes">
+                                    Certificates
+                                </label>
+                            </div> <!-- .govuk-radios__item  -->
+                        </div> <!-- .govuk-radios  -->
+                    </div>
+                </div>
+
+                <div class="rd-sheet-selector-previews">
+                    <div class="selectable" aria-hidden="true">
+                        <table class="govuk-body selectable" style="width: 100%">
+                            <div class="govuk-hint">
+                                First 10 rows of 'Commodities'
+                            </div>
+                            <tbody>
+                                <tr>
+                                    <td>Commodity code</td>
+                                    <td>Commodity suffix</td>
+                                    <td>Description</td>
+                                    <td>Valid from</td>
+                                    <td>Valid until</td>
+                                    <td>Parent code</td>
+                                    <td>Parent suffix</td>
+                                </tr>
+                                <tr>
+                                    <td>0100000000</td>
+                                    <td>80</td>
+                                    <td>LIVE ANIMALS</td>
+                                    <td>1971-12-31</td>
+                                    <td>&nbsp;</td>
+                                    <td>&nbsp;</td>
+                                    <td>&nbsp;</td>
+                                </tr>
+                                <tr>
+                                    <td>0101000000</td>
+                                    <td>80</td>
+                                    <td>Live horses, asses, mules and hinnies</td>
+                                    <td>1972-01-01</td>
+                                    <td>&nbsp;</td>
+                                    <td>0100000000</td>
+                                    <td>80</td>
+                                </tr>
+                                <tr>
+                                    <td>0101210000</td>
+                                    <td>10</td>
+                                    <td>Horses</td>
+                                    <td>2012-01-01</td>
+                                    <td>&nbsp;</td>
+                                    <td>0101000000</td>
+                                    <td>80</td>
+                                </tr>
+                                <tr>
+                                    <td>0101210000</td>
+                                    <td>80</td>
+                                    <td>Pure-bred breeding animals</td>
+                                    <td>2012-01-01</td>
+                                    <td>&nbsp;</td>
+                                    <td>0101210000</td>
+                                    <td>10</td>
+                                </tr>
+                                <tr>
+                                    <td>0101290000</td>
+                                    <td>80</td>
+                                    <td>Other</td>
+                                    <td>2012-01-01</td>
+                                    <td>&nbsp;</td>
+                                    <td>0101210000</td>
+                                    <td>10</td>
+                                </tr>
+                                <tr>
+                                    <td>0101291000</td>
+                                    <td>80</td>
+                                    <td>For slaughter</td>
+                                    <td>2012-01-01</td>
+                                    <td>&nbsp;</td>
+                                    <td>0101290000</td>
+                                    <td>80</td>
+                                </tr>
+                                <tr>
+                                    <td>0101300000</td>
+                                    <td>80</td>
+                                    <td>Asses</td>
+                                    <td>2012-01-01</td>
+                                    <td>&nbsp;</td>
+                                    <td>0101000000</td>
+                                    <td>80</td>
+                                </tr>
+                                <tr>
+                                    <td>0101900000</td>
+                                    <td>80</td>
+                                    <td>Other</td>
+                                    <td>2002-01-01</td>
+                                    <td>&nbsp;</td>
+                                    <td>0101000000</td>
+                                    <td>80</td>
+                                </tr>
+                                <tr>
+                                    <td>0101299000</td>
+                                    <td>80</td>
+                                    <td>Other</td>
+                                    <td>2012-01-01</td>
+                                    <td>&nbsp;</td>
+                                    <td>0101290000</td>
+                                    <td>80</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <div class="selectable" aria-hidden="true">
+                        <div class="govuk-hint">
+                            First 7 rows of 'Footnotes'
+                        </div>
+                        <table class="govuk-body selectable" style="width: 100%;">
+                            <tbody>
+                                <tr>
+                                    <td>Footnode type</td>
+                                    <td>Footnote ID</td>
+                                    <td>Description</td>
+                                    <td>Valid from</td>
+                                    <td>Valid until</td>
+                                </tr>
+                                <tr>
+                                    <td>SN</td>
+                                    <td>040</td>
+                                    <td></td>
+                                    <td>2022-04-14</td>
+                                    <td>2022-10-13</td>
+                                </tr>
+                                <tr>
+                                    <td>DS</td>
+                                    <td>110</td>
+                                    <td>This suspension only applies to 1,4,7,10-Tetraazacyclododecane (CAS RN 294-90-6)</td>
+                                    <td>2022-01-01</td>
+                                    <td>2024-08-31</td>
+                                </tr>
+                                <tr>
+                                    <td>DS</td>
+                                    <td>111</td>
+                                    <td>This suspension only applies to Colourant C.I. Disperse Yellow 241(CAS RN 83249-52-9) and preparations based thereon with a colourant C.I. Disperse Yellow 241content of 97% or more by weight falling under this commodity code</td>
+                                    <td>2022-01-01</td>
+                                    <td>2024-08-31</td>
+                                </tr>
+                                <tr>
+                                    <td>DS</td>
+                                    <td>112</td>
+                                    <td>This suspension only applies to Colourant C.I Direct Black 168, in powder form for leather dyeing (CAS RN 85631-88-5) and preparations based thereon with a colourant C.I. Direct Black 168content by weight of 75% or more</td>
+                                    <td>2022-01-01</td>
+                                    <td>2024-08-31</td>
+                                </tr>
+                                <tr>
+                                    <td>DS</td>
+                                    <td>113</td>
+                                    <td>This suspension only applies to Colourant C.I. Vat Blue 1(CAS RN 482-89-3) and preparations based thereon with a colourant C.I. Vat Blue 1content of 94% or more by weight falling under this commodity code</td>
+                                    <td>2022-01-01</td>
+                                    <td>2024-08-31</td>
+                                </tr>
+                                <tr>
+                                    <td>DS</td>
+                                    <td>114</td>
+                                    <td>This suspension only applies to: Preparation, consisting of a suspension of tepraloxydim (ISO), containing by weight:
+    &bull; 30% or more of tepraloxydim (ISO), and
+    &bull; not more than 70% of a petroleum fraction consisting of aromatic hydrocarbons</td>
+                                    <td>2022-01-01</td>
+                                    <td>2024-08-31</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <div class="selectable" aria-hidden="true">
+                        <table class="govuk-body selectable" style="width: 100%;">
+                            <caption class="govuk-hint" style="text-align: inherit;">
+                                First 7 rows of 'Certificates'
+                            </caption>
+                            <tbody>
+                                <tr><td>Certificate type</td>
+                                <td>Certificate ID</td>
+                                <td>Description</td>
+                                <td>Valid from</td>
+                                <td>Valid until</td>
+                                </tr>
+                                <tr><td>9</td>
+                                <td>99L</td>
+                                <td>CDS universal waiver</td>
+                                <td>2022-01-29</td>
+                                <td>2023-09-30</td>
+                                </tr>
+                                <tr><td>Y</td>
+                                <td>061</td>
+                                <td>Reference to Annex 5-A of Council Decision (EU) 2017/37 (OJ L 11)</td>
+                                <td>2017-09-21</td>
+                                <td>2018-03-02</td>
+                                </tr>
+                                <tr><td>Y</td>
+                                <td>035</td>
+                                <td>Multi-component integrated circuits (MCOs) according to Annex I, Part One, Section II, letter G of Regulation (EEC) No 2658/87</td>
+                                <td>2016-07-01</td>
+                                <td>2016-12-31</td>
+                                </tr>
+                                <tr><td>Y</td>
+                                <td>059</td>
+                                <td>Preparations or mixtures not containing acesulfame potassium (potassium salt of 6-methyl- 1,2,3-oxathiazin-4(3H)-one 2,2-dioxide; CAS RN 55589-62-3)</td>
+                                <td>2015-05-22</td>
+                                <td>2016-12-31</td>
+                                </tr>
+                                <tr><td>U</td>
+                                <td>098</td>
+                                <td>Declaration of origin (Annex II of Commission Implementing Regulation (EU) 2015/787)</td>
+                                <td>2015-05-22</td>
+                                <td>2016-12-31</td>
+                                </tr>
+                                <tr><td>Y</td>
+                                <td>060</td>
+                                <td>Peparations or mixtures containing acesulfame potassium (potassium salt of 6-methyl- 1,2,3-oxathiazin-4(3H)-one 2,2-dioxide; CAS RN 55589-62-3) with the same origin as the preparations or mixtures themselves</td>
+                                <td>2015-05-22</td>
+                                <td>2016-12-31</td>
+                                </tr></tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+
+            <div class="govuk-tabs" data-module="govuk-tabs">
+                <h2 class="govuk-tabs__title">
+                    Code snippets
+                </h2>
+                <ul class="govuk-tabs__list">
+                    <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
+                        <a class="govuk-tabs__tab" href="#html">
+                            HTML
+                        </a>
+                    </li>
+                    <li class="govuk-tabs__list-item">
+                        <a class="govuk-tabs__tab" href="#nunjucks">
+                            Nunjucks
+                        </a>
+                    </li>
+                </ul>
+                <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="html">
+                    <p>Create radio buttons for each sheet using the <a
+                    href="https://design-system.service.gov.uk/components/radios/">GOV.UK
+                    Design System Radios component</a> and then lay out up to 10
+                    rows of data for each sheet using <a
+                    href="component-table-view.html">Table view
+                    components</a>.</p>
+
+                    <p>Add the <code>rd-sheet-preview</code> class to the
+                    <code>govuk-radios</code> container. Add a
+                    <code>data-preview-index</code> attribute to each
+                    <code>&lt;input type="radio"&gt;</code> which should be the
+                    index of the table view to display when this radio button is
+                    checked.</p>
+
+                    <p>You can pre-populate a default sheet to be displayed by
+                    adding the <code>checked</code> attribute to its
+                    corresponding radio button.</p>
+
+                    <pre>&lt;div class="govuk-radios rd-sheet-preview" data-module="govuk-radios"&gt;
+    &lt;div class="govuk-radios__item"&gt;
+        &lt;input class="govuk-radios__input" type="radio" id="Commodities"
+            name="sheet" value="Commodities" data-preview-index="0"&gt;
+        &lt;label class="govuk-label govuk-radios__label" for="Commodities"&gt;
+            Commodities
+        &lt;/label&gt;
+    &lt;/div&gt;
+    &lt;!-- Put more radio button items here --&gt;
+&lt;/div&gt;</pre>
+
+                    <p>Wrap the table views in an element with class
+                    <code>rd-sheet-selector-previews</code>. Use a
+                    <code>&lt;caption&gt;</code> element to display how many
+                    rows from the sheet are being shown.</p>
+
+                    <pre>&lt;div class="rd-sheet-selector-previews"&gt;
+    &lt;div&gt;
+        &lt;!-- Put table view here --&gt;
+    &lt;/div&gt;
+    &lt;!-- Put more table views here --&gt;
+&lt;/div&gt;</pre>
+                </div>
+                <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="nunjucks">
+                    <p>In the Prototype Kit, call the <code>importerSheetSelector</code> macro to
+                        automatically display a sheet selector and associated data previews.</p>
+                    <pre>{% from "importer/macros/sheet_selector.njk" import importerSheetSelector %}
+{{ importerSheetSelector(data) }}</pre>
+                    <p>The macro accepts the following options:</p>
+                    <table class="govuk-table">
+                        <caption class="govuk-table__caption"><code>importerSheetSelector</code> options</caption>
+                        <thead class="govuk-table__head">
+                            <tr class="govuk-table__row">
+                                <th class="govuk-table__header" scope="col">Name</th>
+                                <th class="govuk-table__header" scope="col">Type</th>
+                                <th class="govuk-table__header" scope="col">Description</th>
+                            </tr>
+                        </thead>
+                        <tbody class="govuk-table__body">
+                            <tr class="govuk-table__row">
+                                <th class="govuk-table__header" scope="row">data</th>
+                                <td class="govuk-table__cell">Prototype Kit session</td>
+                                <td class="govuk-table__cell">The automatically
+                                populated <code>data</code> variable containing
+                                the user's uploaded sheet and options.</td>
+                            </tr>
+                            <tr class="govuk-table__row">
+                                <th class="govuk-table__header" scope="row">legend</th>
+                                <td class="govuk-table__cell">Text (optional, default: blank)</td>
+                                <td class="govuk-table__cell">The heading to describe the purpose of the radio buttons.</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+
+            <h2 class="govuk-heading-l">When to use this component</h2>
+            <p>Use this component when users can only submit a single sheet of data to the service.</p>
+            <p>It is sometimes still helpful to show the selector even when the
+            user's uploaded file contains a single sheet, as the data preview
+            helps confirm that they have selected the correct file.</p>
+
+            <h2 class="govuk-heading-l">When to not use this component</h2>
+            <p>Do not use this component to display all of the user's data from
+            each sheet. Up to 10 rows are usually sufficient for users to
+            identify the correct sheet.
+            </p>
+
+            <h2 class="govuk-heading-l">Accessibility</h2>
+            <p>The design of the sheet selector includes some accessibility features:</p>
+            <ul class="govuk-list govuk-list--bullet">
+                <li>Vertical space is reserved for the tallest sheet preview
+                which prevents vertical shift of the rest of the page when the
+                sheet selection is changed. <a
+                href="https://www.w3.org/WAI/WCAG21/Understanding/animation-from-interactions">Avoiding motion of elements is
+                important for users with vestibular
+                disorders (WCAG 2.1)</a>.</li>
+                <li>Previews of unselected sheets are hidden using a CSS
+                <code>visibility: hidden</code> rule to <a
+                href="https://developer.mozilla.org/en-US/docs/Web/CSS/visibility#accessibility">prevent
+                their content being announced by screen readers</a>.</li>
+                <li>The number of rows and sheet name of each preview is
+                captioned using a
+                <code>&lt;caption&gt;</code>
+                which provides <a
+                href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/caption">an
+                accessible description</a>.</li>
+                <li>Sheet previews are shown using the accessible <a
+                href="component-table-view.html">Table view component</a>.</li>
+            </ul>
+        </main>
+    </div>
+    <footer class="govuk-footer">
+        <div class="govuk-width-container">
+            <div class="govuk-footer__meta">
+                <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
+                    <svg aria-hidden="true" focusable="false" class="govuk-footer__licence-logo"
+                        xmlns="http://www.w3.org/2000/svg" viewBox="0 0 483.2 195.7" height="17" width="41">
+                        <path fill="currentColor"
+                            d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145" />
+                    </svg>
+                    <span class="govuk-footer__licence-description">
+                        All content is available under the
+                        <a class="govuk-footer__link"
+                            href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                            rel="license">Open Government Licence v3.0</a>, except where otherwise stated
+                    </span>
+                </div>
+                <div class="govuk-footer__meta-item">
+                    <a href="https://www.register-dynamics.co.uk"
+                        class="govuk-footer__link govuk-footer__copyright-logo rd-logo">
+                        &copy; Register Dynamics 2024
+                    </a>
+                </div>
+            </div>
+        </div>
+    </footer>
+</body>
+
+</html>

--- a/lib/importer/assets/docs/component-table-view.html
+++ b/lib/importer/assets/docs/component-table-view.html
@@ -76,7 +76,7 @@
         <main class="govuk-main-wrapper" id="main-content">
             <span class="govuk-caption-xl">Components</span>
             <h1 class="govuk-heading-xl">Table view</h1>
-            <p class="govuk-body">Display data as a table in rows and columns.</p>
+            <p>Display data as a table in rows and columns.</p>
 
             <table class="govuk-body selectable" style="width: 100%">
                 <thead>
@@ -192,7 +192,7 @@
                     </li>
                 </ul>
                 <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="html">
-                    <p class="govuk-body">Lay out your data using a normal HTML <code>&lt;table&gt;</code> and apply the
+                    <p>Lay out your data using a normal HTML <code>&lt;table&gt;</code> and apply the
                         class <code>selectable</code>.</p>
                     <pre>&lt;table class=&quot;govuk-body selectable&quot;&gt;
     &lt;thead&gt;
@@ -220,26 +220,61 @@
 &lt;/table&gt;</pre>
                 </div>
                 <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="nunjucks">
-                    <p class="govuk-body">In the Prototype Kit, call the <code>importerTableView</code> macro to
+                    <p>In the Prototype Kit, call the <code>importerTableView</code> macro to
                         automatically display a table of previously uploaded data.</p>
                     <pre>{% from "importer/macros/table_view.njk" import importerTableView %}
 {{ importerTableView(data) }}</pre>
+                    <p>The macro accepts the following options:</p>
+                    <table class="govuk-table">
+                        <caption class="govuk-table__caption"><code>importerTableView</code> options</caption>
+                        <thead class="govuk-table__head">
+                            <tr class="govuk-table__row">
+                                <th class="govuk-table__header" scope="col">Name</th>
+                                <th class="govuk-table__header" scope="col">Type</th>
+                                <th class="govuk-table__header" scope="col">Description</th>
+                            </tr>
+                        </thead>
+                        <tbody class="govuk-table__body">
+                            <tr class="govuk-table__row">
+                                <th class="govuk-table__header" scope="row">data</th>
+                                <td class="govuk-table__cell">Prototype Kit session</td>
+                                <td class="govuk-table__cell">The automatically
+                                    populated <code>data</code> variable containing
+                                    the user's uploaded sheet and options.</td>
+                            </tr>
+                            <tr class="govuk-table__row">
+                                <th class="govuk-table__header" scope="row">hideHeader</th>
+                                <td class="govuk-table__cell">True or false (optional, default: false)</td>
+                                <td class="govuk-table__cell">Whether the
+                                    headers that the user has selected should be
+                                    hidden or visible.</td>
+                            </tr>
+                            <tr class="govuk-table__row">
+                                <th class="govuk-table__header" scope="row">caption</th>
+                                <td class="govuk-table__cell">Text (optional, default: blank)</td>
+                                <td class="govuk-table__cell">The caption that
+                                    should be added to describe the content of the
+                                    table view.</td>
+                            </tr>
+                        </tbody>
+                    </table>
                 </div>
             </div>
 
             <h2 class="govuk-heading-l">When to use this component</h2>
-            <p class="govuk-body">Use this component to:</p>
+            <p>Use this component to:</p>
             <ul class="govuk-list govuk-list--bullet">
                 <li>show a preview of data to help the user pick the right file or worksheet</li>
                 <li>display a subset of data that requires manual review</li>
             </ul>
 
             <h2 class="govuk-heading-l">When to not use this component</h2>
-            <p class="govuk-body">Do not use this component to display all of the user's data for them to review. Asking
+            <p>Do not use this component to display all of the user's data for them to review. Asking
                 the users to review data is not an effective way to catch mistakes if the data is larger than a few
                 cells. Instead, display summary statistics about the submitted data relevant to the user journey.</p>
-            <p class="govuk-body">Do not use this component to display data not submitted by the user. Instead, use
-                another Design System component or a regular table.</p>
+            <p>Do not use this component to display data not submitted by the
+                user. Instead, use the <a href="https://design-system.service.gov.uk/components/table/">GOV.UK
+                    Design System Table component</a> or a regular table.</p>
         </main>
     </div>
     <footer class="govuk-footer">

--- a/lib/importer/assets/docs/docs.css
+++ b/lib/importer/assets/docs/docs.css
@@ -51,6 +51,7 @@
     grid-template-columns: 200px 1fr;
     column-gap: 3em;
     row-gap: 3em;
+    margin-bottom: 3em;
 }
 
 code {
@@ -58,6 +59,7 @@ code {
     background-color: #f3f2f1;
     font-size: 1rem;
     line-height: 1.25;
+    display: inline-block;
 }
 
 table.selectable {

--- a/lib/importer/assets/docs/docs.css
+++ b/lib/importer/assets/docs/docs.css
@@ -62,6 +62,12 @@ code {
     display: inline-block;
 }
 
+.example {
+    padding: 1em;
+    border: 1px solid #b1b4b6;
+    margin-bottom: 2em;
+}
+
 table.selectable {
     width: 33%;
     border: solid 1px #aaa;

--- a/lib/importer/assets/docs/docs.css
+++ b/lib/importer/assets/docs/docs.css
@@ -12,7 +12,6 @@
     transform-origin: top left;
     height: 500%;
     font-size: 3rem;
-    color: lightgray;
 }
 
 .rd-service-card [class^="govuk-heading"] {
@@ -25,11 +24,19 @@
     font-size: 300%;
 }
 
+.rd-service-card .fake {
+    color: lightgray;
+}
+
 .rd-service-card p:last-of-type {
     margin-bottom: 3em;
 }
 
-.rd-service-card .govuk-main-wrapper>[class^="govuk"]:not([class^="govuk-heading"], [class^="govuk-panel"]) {
+.rd-service-card .govuk-main-wrapper>[class^="govuk"]:not(
+    [class^="govuk-heading"],
+    [class^="govuk-panel"],
+    [class^="govuk-grid-column"]
+) {
     transform: scale(3);
     transform-origin: top left;
 }

--- a/lib/importer/assets/docs/index.html
+++ b/lib/importer/assets/docs/index.html
@@ -54,8 +54,10 @@
             <p class="govuk-body">
                 The Tabular Data Importer is a set of components and patterns for asking users for data as a
                 spreadsheet. These patterns are useful when users need to provide a lot of information at once to a
-                service and are likely to be drawing the information from an existing source. They are compatible with
-                the GOV.UK Design System.
+                service and are likely to be drawing the information from an existing source.</p>
+            <p>They can be used as part of the Prototype Kit and also in
+                production use as part of a real service. Their designs are
+                compatible with the GOV.UK Design System.
             </p>
 
             <h2 class="govuk-heading-l">Patterns</h2>
@@ -73,6 +75,7 @@
             <p class="govuk-body">
                 The Importer is available as a software package that can be installed into the Prototype Kit.
             </p>
+            <h3 class="govuk-heading-m">Installation</h3>
             <div data-static-only>
                 <p class="govuk-body">Install the plugin by typing:</p>
                 <pre>npm install 'https://gitpkg.vercel.app/register-dynamics/data-import/lib/importer?main'</pre>
@@ -83,13 +86,17 @@
                 <span class="govuk-tag govuk-tag--green">Installed</span>
                 You have already installed the plugin and it is ready to be used in this prototype.
             </p>
-            <p class="govuk-body">Now add these lines to the bottom of <code>app/routes.js</code> to configure the prototype to receive and
+            <p class="govuk-body">Now add these lines to the bottom of <code>app/routes.js</code> to configure the
+                prototype to receive and
                 process
                 spreadsheets:</p>
             <pre>const importer = require("@register-dynamics/importer");
 const cfg = require("govuk-prototype-kit/lib/config");
 importer.Initialise(cfg.getConfig(), router, govukPrototypeKit);</pre>
-            <p class="govuk-body">Finally, add some fields to <code>app/config.js</code> that the user will be asked for when using the
+
+            <h3 class="govuk-heading-m">Configuration</h3>
+            <p class="govuk-body">Finally, add some fields to <code>app/config.js</code> that the user will be asked for
+                when using the
                 "Identify columns" template:</p>
             <pre>"fields": [
     "Code",

--- a/lib/importer/assets/docs/index.html
+++ b/lib/importer/assets/docs/index.html
@@ -51,7 +51,7 @@
     <div class="govuk-width-container">
         <main class="govuk-main-wrapper" id="main-content">
             <h1 class="govuk-heading-xl">Tabular Data Importer</h1>
-            <p class="govuk-body">
+            <p>
                 The Tabular Data Importer is a set of components and patterns for asking users for data as a
                 spreadsheet. These patterns are useful when users need to provide a lot of information at once to a
                 service and are likely to be drawing the information from an existing source.</p>
@@ -69,24 +69,25 @@
             <h2 class="govuk-heading-l">Components</h2>
             <ul class="govuk-list">
                 <li><a class="govuk-link" href="./component-table-view.html">Table view</a></li>
+                <li><a class="govuk-link" href="./component-sheet-selector.html">Sheet selector</a></li>
             </ul>
 
             <h2 class="govuk-heading-l">Getting started</h2>
-            <p class="govuk-body">
+            <p>
                 The Importer is available as a software package that can be installed into the Prototype Kit.
             </p>
             <h3 class="govuk-heading-m">Installation</h3>
             <div data-static-only>
-                <p class="govuk-body">Install the plugin by typing:</p>
+                <p>Install the plugin by typing:</p>
                 <pre>npm install 'https://gitpkg.vercel.app/register-dynamics/data-import/lib/importer?main'</pre>
-                <p class="govuk-body">Then run the Prototype Kit and visit the "Manage Prototype" section to get help on
+                <p>Then run the Prototype Kit and visit the "Manage Prototype" section to get help on
                     using the Importer.</p>
             </div>
             <p data-plugin-only class="govuk-body">
                 <span class="govuk-tag govuk-tag--green">Installed</span>
                 You have already installed the plugin and it is ready to be used in this prototype.
             </p>
-            <p class="govuk-body">Now add these lines to the bottom of <code>app/routes.js</code> to configure the
+            <p>Now add these lines to the bottom of <code>app/routes.js</code> to configure the
                 prototype to receive and
                 process
                 spreadsheets:</p>
@@ -95,7 +96,7 @@ const cfg = require("govuk-prototype-kit/lib/config");
 importer.Initialise(cfg.getConfig(), router, govukPrototypeKit);</pre>
 
             <h3 class="govuk-heading-m">Configuration</h3>
-            <p class="govuk-body">Finally, add some fields to <code>app/config.js</code> that the user will be asked for
+            <p>Finally, add some fields to <code>app/config.js</code> that the user will be asked for
                 when using the
                 "Identify columns" template:</p>
             <pre>"fields": [
@@ -103,7 +104,9 @@ importer.Initialise(cfg.getConfig(), router, govukPrototypeKit);</pre>
     "Name",
     "Speciality"
 ]</pre>
-            <p class="govuk-body">You are now ready to use the Tabular Data Importer.</p>
+            <p>You are now ready to use the Tabular Data
+                Importer. You can get started by following a <a href="./pattern-tabular-data.html">pattern for
+                    requesting tabular data</a>.</p>
         </main>
     </div>
     <footer class="govuk-footer">

--- a/lib/importer/assets/docs/pattern-tabular-data.html
+++ b/lib/importer/assets/docs/pattern-tabular-data.html
@@ -83,9 +83,9 @@
                         </div>
                         <div class="govuk-main-wrapper">
                             <h1 class="govuk-heading-xl">Register a tribble</h1>
-                            <p>████████████████</p>
-                            <p>████████████████</p>
-                            <p>████████</p>
+                            <p class="fake">████████████████</p>
+                            <p class="fake">████████████████</p>
+                            <p class="fake">████████</p>
                             <a role="button" draggable="false" class="govuk-button govuk-button--start"
                                 data-module="govuk-button">
                                 Start now
@@ -113,9 +113,9 @@
                         </div>
                         <div class="govuk-main-wrapper">
                             <h1 class="govuk-heading-m">Upload a file</h1>
-                            <p>████████████████</p>
-                            <p>████████████████</p>
-                            <p>████████</p>
+                            <p class="fake">████████████████</p>
+                            <p class="fake">████████████████</p>
+                            <p class="fake">████████</p>
                             <div class="govuk-form-group">
                                 <label class="govuk-label" for="file-upload-1">
                                     Upload a file
@@ -185,19 +185,20 @@
                 </div>
                 <div class="rd-service-text">
                     <h2 class="govuk-heading-m">User selects a worksheet (optional)</h2>
+                    <p class="govuk-body">Users often include explanatory information, summaries, pivot tables or charts
+                        on extra sheets. Your service should allow them to ignore these.</p>
                     <p class="govuk-body">If the file type supports multiple sheets (i.e. it is a Microsoft Excel (XLSX)
                         file or OpenDocument Sheets (ODS) file), use the <a
                             href="https://design-system.service.gov.uk/components/radios/">GOV.UK Design System
                             radios component</a> to get the user to select one of the sheets.</p>
-                    <p class="govuk-body">Users often include explanatory information, summaries, pivot tables or charts
-                        on extra sheets. Your service should allow them to ignore these.</p>
+                    <p class="govuk-body">You can skip this step if the file only contains one sheet.</p>
                     <a href="/manage-prototype/templates/install?package=%40register-dynamics%2Fimporter&template=%2Ftemplates%2Fselect_sheet.html"
                         role="button" data-plugin-only draggable="false" class="govuk-button govuk-button--secondary"
                         data-module="govuk-button">
                         Create from template
                     </a>
                 </div>
-                <div class="rd-service-card later">
+                <div class="rd-service-card">
                     <div class="rd-service-card-inner">
                         <div class="govuk-header">
                             <div class="govuk-header__container govuk-width-container">
@@ -208,22 +209,52 @@
                         </div>
                         <div class="govuk-main-wrapper">
                             <h1 class="govuk-heading-m">Select your data</h1>
-                            <p>████████████████</p>
-                            <p>TODO</p>
+                            <div class="govuk-form-group">
+                                <table class="selectable govuk-body">
+                                    <tbody>
+                                        <tr>
+                                            <td class="selected top left bottom">A</td>
+                                            <td class="selected top bottom">B</td>
+                                            <td class="selected top right bottom">C</td>
+                                        </tr>
+                                        <tr>
+                                            <td>aaa</td>
+                                            <td>bbb</td>
+                                            <td>ccc</td>
+                                        </tr>
+                                        <tr>
+                                            <td>zzz</td>
+                                            <td>yyy</td>
+                                            <td>xxx</td>
+                                        </tr>
+                                        <tr>
+                                            <td>mmm</td>
+                                            <td>nnn</td>
+                                            <td>ooo</td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </div>
                         </div>
                     </div>
                 </div>
                 <div class="rd-service-text">
-                    <h2 class="govuk-heading-m">User selects column headers (coming soon)</h2>
-                    <p class="govuk-body">Use the <a href="./component-table-view.html">sheet view component</a> in
-                        <code>select-columns</code> mode to
-                        display the contents of the selected spreadsheet and ask the user to select column headers.</p>
-                    <p class="govuk-body">Spreadsheets often have extra titles above the first row of headers that
+                    <h2 class="govuk-heading-m">User selects column headers</h2>
+                    <p class="govuk-body">Users often add extra titles above the first row of headers that
                         should be ignored.
                         Data may also not start in the first column as users often leave blank columns to provide
                         padding.</p>
+                    <p class="govuk-body">Use the <a href="./component-table-view.html">table view component</a>
+                        in to display the contents of the selected spreadsheet and
+                        ask the user to select column headers.
+                    </p>
+                    <a href="/manage-prototype/templates/install?package=%40register-dynamics%2Fimporter&template=%2Ftemplates%2Fselect_header_row.html"
+                        role="button" data-plugin-only draggable="false" class="govuk-button govuk-button--secondary"
+                        data-module="govuk-button">
+                        Create from template
+                    </a>
                 </div>
-                <div class="rd-service-card later">
+                <div class="rd-service-card">
                     <div class="rd-service-card-inner">
                         <div class="govuk-header">
                             <div class="govuk-header__container govuk-width-container">
@@ -234,18 +265,51 @@
                         </div>
                         <div class="govuk-main-wrapper">
                             <h1 class="govuk-heading-m">Select your data</h1>
-                            <p>████████████████</p>
-                            <p>TODO</p>
+                            <div class="govuk-form-group">
+                                <table class="selectable govuk-body">
+                                    <thead>
+                                        <tr>
+                                            <th>A</th>
+                                            <th>B</th>
+                                            <th>C</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <tr>
+                                            <td>aaa</td>
+                                            <td>bbb</td>
+                                            <td>ccc</td>
+                                        </tr>
+                                        <tr>
+                                            <td>zzz</td>
+                                            <td>yyy</td>
+                                            <td>xxx</td>
+                                        </tr>
+                                        <tr>
+                                            <td class="selected top left bottom">mmm</td>
+                                            <td class="selected top bottom">nnn</td>
+                                            <td class="selected top right bottom">ooo</td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </div>
                         </div>
                     </div>
                 </div>
                 <div class="rd-service-text">
-                    <h2 class="govuk-heading-m">User selects bottom of sheet (coming soon)</h2>
-                    <p class="govuk-body">Use the <a href="./component-table-view.html">sheet view component</a> in
-                        <code>select-bottom</code> mode to
-                        display the contents of the selected spreadsheet and ask the user to select where rows end.</p>
-                    <p class="govuk-body">Spreadsheets often have extra summary rows after the last row of data that
-                        should be ignored.</p>
+                    <h2 class="govuk-heading-m">User selects bottom of their data</h2>
+                    <p class="govuk-body">Users often include extra summary rows
+                        (such as "subtotals") after the last row of data that should
+                        be ignored.</p>
+                    <p class="govuk-body">Use the <a href="./component-table-view.html">table view component</a>
+                        to display the contents of the selected spreadsheet and
+                        ask the user to select where rows end.
+                    </p>
+                    <a href="/manage-prototype/templates/install?package=%40register-dynamics%2Fimporter&template=%2Ftemplates%2Fselect_footer_row.html"
+                        role="button" data-plugin-only draggable="false" class="govuk-button govuk-button--secondary"
+                        data-module="govuk-button">
+                        Create from template
+                    </a>
                 </div>
                 <div class="rd-service-card">
                     <div class="rd-service-card-inner">
@@ -258,20 +322,50 @@
                         </div>
                         <div class="govuk-main-wrapper">
                             <h1 class="govuk-heading-m">Identify your columns</h1>
-                            <p>████████████████</p>
-                            <p>TODO</p>
+                            <div class="govuk-grid-column-two-thirds" style="margin-bottom: 1em;">
+                                <label class="govuk-label govuk-label--s fake"
+                                    style="float:left">████████████████</label>
+                                <select class="govuk-select" style="float: right;" name="0"></select>
+                            </div>
+                            <div class="govuk-grid-column-two-thirds" style="margin-bottom: 1em;">
+                                <label class="govuk-label govuk-label--s fake"
+                                    style="float:left">████████████████</label>
+                                <select class="govuk-select" style="float: right;" name="0"></select>
+                            </div>
+                            <div class="govuk-grid-column-two-thirds" style="margin-bottom: 1em;">
+                                <label class="govuk-label govuk-label--s fake"
+                                    style="float:left">████████████████</label>
+                                <select class="govuk-select" style="float: right;" name="0"></select>
+                            </div>
+                            <div class="govuk-grid-column-two-thirds" style="margin-bottom: 1em;">
+                                <label class="govuk-label govuk-label--s fake"
+                                    style="float:left">████████████████</label>
+                                <select class="govuk-select" style="float: right;" name="0"></select>
+                            </div>
+                            <div class="govuk-grid-column-two-thirds" style="margin-bottom: 1em;">
+                                <label class="govuk-label govuk-label--s fake"
+                                    style="float:left">████████████████</label>
+                                <select class="govuk-select" style="float: right;" name="0"></select>
+                            </div>
+                            <div class="govuk-grid-column-two-thirds" style="margin-bottom: 1em;">
+                                <label class="govuk-label govuk-label--s fake"
+                                    style="float:left">████████████████</label>
+                                <select class="govuk-select" style="float: right;" name="0"></select>
+                            </div>
                         </div>
                     </div>
                 </div>
                 <div class="rd-service-text">
                     <h2 class="govuk-heading-m">User maps input columns to required names</h2>
-                    <p class="govuk-body">Use the <a href="component-table-view.html">sheet view component</a> in
-                        <code>mapping</code> mode to
-                        select which columns in the input spreadsheet correspond to required data for your service.</p>
-                    <p class="govuk-body">Spreadsheets often have extra columns
-                        (such as "notes") in amongst the columns of interest so
-                        users can select to ignore columns. Each required column can
-                        be mapped to a single input column.</p>
+                    <p class="govuk-body">Uesrs often include extra columns
+                        (such as "notes") in amongst the columns of interest. Your
+                        service should allow users to ignore these. They may also
+                        pick different names for columns depending on their other
+                        needs.</p>
+                    <p class="govuk-body">Use a set of select dropdowns to allow
+                        the user to select which columns in the input spreadsheet
+                        correspond to required data for your service.
+                    </p>
                     <a href="/manage-prototype/templates/install?package=%40register-dynamics%2Fimporter&template=%2Ftemplates%2Fmapping.html"
                         role="button" data-plugin-only draggable="false" class="govuk-button govuk-button--secondary"
                         data-module="govuk-button">
@@ -331,13 +425,16 @@
                 </div>
                 <div class="rd-service-text">
                     <h2 class="govuk-heading-m">User reviews rejected rows</h2>
-                    <p class="govuk-body">Use the <a href="component-table-view.html">table view component</a> in
-                        <code>review</code> mode to
-                        display the results of row validation and highlight any rows that weren't considered valid.</p>
+                    <p class="govuk-body">Use the <a href="component-table-view.html">table view component</a>
+                        to display the results of row validation and highlight any
+                        rows that weren't considered valid.
+                    </p>
                     <p class="govuk-body">The component will also display a summary of the number of
                         rows it contains, and how many are not valid.</p>
-                    <p class="govuk-body">The user should then be able to go back to modify any options that might fix
-                        the issue or upload a different spreadsheet with any broken rows fixed.</p>
+                    <p class="govuk-body">Users should then be able to go back to modify any options that might fix
+                        the issue or upload a different spreadsheet with any broken rows fixed. Depending on your
+                        service, you may also allow users to proceed with the valid rows and come back later to upload
+                        new rows to replace the invalid ones.</p>
                     <a href="/manage-prototype/templates/install?package=%40register-dynamics%2Fimporter&template=%2Ftemplates%2Freview.html"
                         role="button" data-plugin-only draggable="false" class="govuk-button govuk-button--secondary"
                         data-module="govuk-button">
@@ -362,9 +459,9 @@
                                     You applied for <strong>456</strong> licenses
                                 </div>
                             </div>
-                            <p>████████████████</p>
-                            <p>████████████████</p>
-                            <p>████████</p>
+                            <p class="fake">████████████████</p>
+                            <p class="fake">████████████████</p>
+                            <p class="fake">████████</p>
                         </div>
                     </div>
                 </div>

--- a/lib/importer/assets/docs/pattern-tabular-data.html
+++ b/lib/importer/assets/docs/pattern-tabular-data.html
@@ -66,7 +66,7 @@
         <main class="govuk-main-wrapper" id="main-content">
             <span class="govuk-caption-xl">Ask users for</span>
             <h1 class="govuk-heading-xl">Tabular data</h1>
-            <p class="govuk-body">
+            <p>
                 Ask users to supply a spreadsheet of data, select the data from their spreadsheet that is relevant to
                 your service, and review that the supplied data matches the service's expectations.
             </p>
@@ -99,7 +99,7 @@
                 </div>
                 <div class="rd-service-text">
                     <h2 class="govuk-heading-m">Start the user journey</h2>
-                    <p class="govuk-body">Explain to users that they are about to upload data, and what data will be
+                    <p>Explain to users that they are about to upload data, and what data will be
                         required.</p>
                 </div>
                 <div class="rd-service-card">
@@ -126,8 +126,9 @@
                     </div>
                 </div>
                 <div class="rd-service-text">
+                    <a name="upload-a-file"></a>
                     <h2 class="govuk-heading-m">User selects a spreadsheet</h2>
-                    <p class="govuk-body">Use the <a
+                    <p>Use the <a
                             href="https://design-system.service.gov.uk/components/file-upload/">GOV.UK Design System
                             file upload component</a>
                         to get the user to select a file.</p>
@@ -185,13 +186,13 @@
                 </div>
                 <div class="rd-service-text">
                     <h2 class="govuk-heading-m">User selects a worksheet (optional)</h2>
-                    <p class="govuk-body">Users often include explanatory information, summaries, pivot tables or charts
+                    <p>Users often include explanatory information, summaries, pivot tables or charts
                         on extra sheets. Your service should allow them to ignore these.</p>
-                    <p class="govuk-body">If the file type supports multiple sheets (i.e. it is a Microsoft Excel (XLSX)
+                    <p>If the file type supports multiple sheets (i.e. it is a Microsoft Excel (XLSX)
                         file or OpenDocument Sheets (ODS) file), use the <a
                             href="https://design-system.service.gov.uk/components/radios/">GOV.UK Design System
                             radios component</a> to get the user to select one of the sheets.</p>
-                    <p class="govuk-body">You can skip this step if the file only contains one sheet.</p>
+                    <p>You can skip this step if the file only contains one sheet.</p>
                     <a href="/manage-prototype/templates/install?package=%40register-dynamics%2Fimporter&template=%2Ftemplates%2Fselect_sheet.html"
                         role="button" data-plugin-only draggable="false" class="govuk-button govuk-button--secondary"
                         data-module="govuk-button">
@@ -240,11 +241,11 @@
                 </div>
                 <div class="rd-service-text">
                     <h2 class="govuk-heading-m">User selects column headers</h2>
-                    <p class="govuk-body">Users often add extra titles above the first row of headers that
+                    <p>Users often add extra titles above the first row of headers that
                         should be ignored.
                         Data may also not start in the first column as users often leave blank columns to provide
                         padding.</p>
-                    <p class="govuk-body">Use the <a href="./component-table-view.html">table view component</a>
+                    <p>Use the <a href="./component-table-view.html">table view component</a>
                         in to display the contents of the selected spreadsheet and
                         ask the user to select column headers.
                     </p>
@@ -298,10 +299,10 @@
                 </div>
                 <div class="rd-service-text">
                     <h2 class="govuk-heading-m">User selects bottom of their data</h2>
-                    <p class="govuk-body">Users often include extra summary rows
+                    <p>Users often include extra summary rows
                         (such as "subtotals") after the last row of data that should
                         be ignored.</p>
-                    <p class="govuk-body">Use the <a href="./component-table-view.html">table view component</a>
+                    <p>Use the <a href="./component-table-view.html">table view component</a>
                         to display the contents of the selected spreadsheet and
                         ask the user to select where rows end.
                     </p>
@@ -357,12 +358,12 @@
                 </div>
                 <div class="rd-service-text">
                     <h2 class="govuk-heading-m">User maps input columns to required names</h2>
-                    <p class="govuk-body">Uesrs often include extra columns
+                    <p>Uesrs often include extra columns
                         (such as "notes") in amongst the columns of interest. Your
                         service should allow users to ignore these. They may also
                         pick different names for columns depending on their other
                         needs.</p>
-                    <p class="govuk-body">Use a set of select dropdowns to allow
+                    <p>Use a set of select dropdowns to allow
                         the user to select which columns in the input spreadsheet
                         correspond to required data for your service.
                     </p>
@@ -425,13 +426,13 @@
                 </div>
                 <div class="rd-service-text">
                     <h2 class="govuk-heading-m">User reviews rejected rows</h2>
-                    <p class="govuk-body">Use the <a href="component-table-view.html">table view component</a>
+                    <p>Use the <a href="component-table-view.html">table view component</a>
                         to display the results of row validation and highlight any
                         rows that weren't considered valid.
                     </p>
-                    <p class="govuk-body">The component will also display a summary of the number of
+                    <p>The component will also display a summary of the number of
                         rows it contains, and how many are not valid.</p>
-                    <p class="govuk-body">Users should then be able to go back to modify any options that might fix
+                    <p>Users should then be able to go back to modify any options that might fix
                         the issue or upload a different spreadsheet with any broken rows fixed. Depending on your
                         service, you may also allow users to proceed with the valid rows and come back later to upload
                         new rows to replace the invalid ones.</p>
@@ -467,13 +468,13 @@
                 </div>
                 <div class="rd-service-text">
                     <h2 class="govuk-heading-m">User receives receipt of upload</h2>
-                    <p class="govuk-body">Use the <a
+                    <p>Use the <a
                             href="https://design-system.service.gov.uk/components/panel/">GOV.UK Design
                             System Panel
                             component</a>
                         to provide confirmation that the upload was successfully received and is being processed.
                     </p>
-                    <p class="govuk-body">
+                    <p>
                         The panel component should include any relevant statistics that reassure the user that the
                         correct action is being taken, such as the number of operations that will be carried out in
                         response or the number of affected items.</p>
@@ -484,6 +485,79 @@
                     </a>
                 </div>
             </section>
+
+            <h2 class="govuk-heading-l">Link your data submission pages together</h2>
+            <p>
+                Each page you create from a template needs to be linked to the
+                next page in the user journey. The Prototype Kit documentation
+                explains how to <a
+                    href="https://prototype-kit.service.gov.uk/docs/make-first-prototype/link-pages-together">
+                    link simple pages together</a>.
+            </p>
+            <p>
+                The templates above where the user uploads data, chooses a
+                worksheet, selects headers or footers, or identifies columns use
+                a <code>&lt;form&gt;</code> tag to link pages together. The
+                <code>action</code> on the <code>&lt;form&gt;</code> tag
+                contains a special value that allows the data the user has
+                submitted to be processed before sending them to the next page.
+            </p>
+            <p>
+                For each page you create from one of the above templates:
+            </p>
+            <ol class="govuk-list govuk-list--number">
+                <li>Open the page that you just created</li>
+                <li>Find the line with the <code>&lt;form&gt;</code> tag which has
+                an <code>action</code> attribute that looks like
+                <code>action="&lcub;&lcub;importerSomethingPath&lpar;'/next-page'&rpar;&rcub;&rcub;"</code></li>
+                <li>Change the path in the single quotes to be the next page the user should go to</li>
+            </ol>
+            <p>
+                For example, if you have just created a page from the <a
+                href="#upload-a-file">Upload a file</a> template and want the
+                next page to be <code>/my-custom-page</code>, change the
+                <code>&lt;form&gt;</code> tag in your new page to be:
+                <pre>&lt;form action="&lcub;&lcub;importerUploadPath&lpar;'/my-custom-page'&rpar;&rcub;&rcub;" method="POST" enctype="multipart/form-data"&gt;</pre>
+            </p>
+            <p>
+                Alternatively, use the default names for data submission pages
+                which will link to them from the previous page without any
+                required changes.
+            </p>
+            <table class="govuk-table">
+                <thead class="govuk-table__head">
+                    <tr class="govuk-table__row">
+                        <th scope="col" class="govuk-table__header">Template</th>
+                        <th scope="col" class="govuk-table__header">Default name</th>
+                    </tr>
+                </thead>
+                <tbody class="govuk-table__body">
+                    <tr class="govuk-table__row">
+                        <th scope="row" class="govuk-table__header">Upload a file</th>
+                        <td class="govuk-table__cell"><code>/upload</code></td>
+                    </tr>
+                    <tr class="govuk-table__row">
+                        <th scope="row" class="govuk-table__header">Select a worksheet</th>
+                        <td class="govuk-table__cell"><code>/select-sheet</code></td>
+                    </tr>
+                    <tr class="govuk-table__row">
+                        <th scope="row" class="govuk-table__header">Select header rows</th>
+                        <td class="govuk-table__cell"><code>/select-header-row</code></td>
+                    </tr>
+                    <tr class="govuk-table__row">
+                        <th scope="row" class="govuk-table__header">Identify your columns</th>
+                        <td class="govuk-table__cell"><code>/mapping</code></td>
+                    </tr>
+                    <tr class="govuk-table__row">
+                        <th scope="row" class="govuk-table__header">Review your data</th>
+                        <td class="govuk-table__cell"><code>/review</code></td>
+                    </tr>
+                    <tr class="govuk-table__row">
+                        <th scope="row" class="govuk-table__header">Upload complete</th>
+                        <td class="govuk-table__cell"><code>/success</code></td>
+                    </tr>
+                </tbody>
+            </table>
         </main>
     </div>
     <footer class="govuk-footer">

--- a/lib/importer/govuk-prototype-kit.config.json
+++ b/lib/importer/govuk-prototype-kit.config.json
@@ -15,6 +15,16 @@
       "type": "nunjucks"
     },
     {
+      "name": "Select header rows",
+      "path": "/templates/select_header_row.html",
+      "type": "nunjucks"
+    },
+    {
+      "name": "Select footer rows",
+      "path": "/templates/select_footer_row.html",
+      "type": "nunjucks"
+    },
+    {
       "name": "Identify your columns",
       "path": "/templates/mapping.html",
       "type": "nunjucks"


### PR DESCRIPTION
The documentation should now be complete enough that a designer who wants to install and use the plugin should be able to complete all of the steps as long as they read all of the documentation. 

There are still plenty of improvements to make, but this should get us started?