### PR TITLE
Show an error if an empty sheet is selected

### DIFF
--- a/lib/importer/index.js
+++ b/lib/importer/index.js
@@ -202,6 +202,13 @@ exports.Initialise = (config, router, prototypeKit) => {
       return
     }
 
+    let check = sheets_lib.GetPreview(session, request.body.sheet)
+    if (check == null) {
+      request.session.data[IMPORTER_ERROR_KEY] = "Please select a non-empty sheet"
+      response.redirect(request.get('Referrer'))
+      return
+    }
+
     session.sheet = request.body.sheet;
 
     // In some cases, the user will next select a header row which tells us where


### PR DESCRIPTION
Although we should show all of the sheets available in the sheet selector (to avoid confusion) we may end up in a situation where a user selects an empty sheet.  Previously, we just crashed with a bad range when this happened, but now we instead show the user an error explaining that they need to choose a non-empty sheet.