### PR TITLE
Add playwright for running UI tests

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -25,10 +25,10 @@ jobs:
       run: npx playwright install --with-deps
     - name: Run Playwright tests
       run: npx playwright test
-    - name: LS results
+    - name: Run ls on results
       run: ls -al ./test-results
-    - name: LS CWD
-      run: ls -al
+    - name: Run ls on cwd
+      run: ls -al .
     - uses: actions/upload-artifact@v4
       if: ${{ !cancelled() }}
       with:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -25,6 +25,10 @@ jobs:
       run: npx playwright install --with-deps
     - name: Run Playwright tests
       run: npx playwright test
+    - name: LS results
+      run: ls -al test-results
+    - name: LS CWD
+      run: ls -al
     - uses: actions/upload-artifact@v4
       if: ${{ !cancelled() }}
       with:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,33 @@
+name: Playwright Tests
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+jobs:
+  test:
+    defaults:
+      run:
+        working-directory: ./prototypes/basic
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version: lts/*
+    - name: Install lib dependencies -- todo, check why
+      working-directory: ./lib/importer
+      run: npm i
+    - name: Install dependencies
+      run: npm i
+    - name: Install Playwright Browsers
+      run: npx playwright install --with-deps
+    - name: Run Playwright tests
+      run: npx playwright test
+    - uses: actions/upload-artifact@v4
+      if: ${{ !cancelled() }}
+      with:
+        name: test-results
+        path: ./test-results/
+        retention-days: 30

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -27,8 +27,10 @@ jobs:
       run: npx playwright test
     - name: Run ls on results
       run: ls -al ./test-results
+      if: always()
     - name: Run ls on cwd
       run: ls -al .
+      if: always()
     - uses: actions/upload-artifact@v4
       if: ${{ !cancelled() }}
       with:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -25,12 +25,6 @@ jobs:
       run: npx playwright install --with-deps
     - name: Run Playwright tests
       run: npx playwright test
-    - name: Run ls on results
-      run: ls -al ./test-results
-      if: always()
-    - name: Run ls on cwd
-      run: ls -al .
-      if: always()
     - uses: actions/upload-artifact@v4
       if: always()
       with:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -35,5 +35,5 @@ jobs:
       if: always()
       with:
         name: test-results
-        path: ./test-results/
+        path: ./prototypes/basic/test-results
         retention-days: 30

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -32,8 +32,8 @@ jobs:
       run: ls -al .
       if: always()
     - uses: actions/upload-artifact@v4
-      if: ${{ !cancelled() }}
+      if: always()
       with:
         name: test-results
-        path: test-results/
+        path: ./test-results/
         retention-days: 30

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -29,5 +29,5 @@ jobs:
       if: ${{ !cancelled() }}
       with:
         name: test-results
-        path: ./test-results/
+        path: test-results/
         retention-days: 30

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Run Playwright tests
       run: npx playwright test
     - name: LS results
-      run: ls -al test-results
+      run: ls -al ./test-results
     - name: LS CWD
       run: ls -al
     - uses: actions/upload-artifact@v4

--- a/prototypes/basic/.gitignore
+++ b/prototypes/basic/.gitignore
@@ -1,6 +1,9 @@
 # Node.js ignores
 node_modules/
 
+# Test results
+test-results/
+
 # Prototype ignores - per-user
 .tmp/
 .env

--- a/prototypes/basic/README.md
+++ b/prototypes/basic/README.md
@@ -1,0 +1,11 @@
+# Basic Prototype
+
+This basic prototype exists for development purposes, and to run playwright tests against the implementation.
+
+## Setting up tests
+
+playwright requires specific browser instances to be installed, and these can be installed with
+
+```
+npx playwright install
+```

--- a/prototypes/basic/README.md
+++ b/prototypes/basic/README.md
@@ -9,3 +9,17 @@ playwright requires specific browser instances to be installed, and these can be
 ```
 npx playwright install
 ```
+
+## Running tests
+
+You can run the UI tests with
+
+```
+npm test
+```
+
+To test a specific file, you can use a partial filename after --, such as
+
+```
+npm test -- tribble
+```

--- a/prototypes/basic/package-lock.json
+++ b/prototypes/basic/package-lock.json
@@ -8,7 +8,11 @@
         "@govuk-prototype-kit/common-templates": "2.0.1",
         "@register-dynamics/importer": "file:../../lib/importer",
         "govuk-frontend": "5.4.1",
-        "govuk-prototype-kit": "13.16.2"
+        "govuk-prototype-kit": "13.16.2",
+        "playwright": "^1.47.1"
+      },
+      "devDependencies": {
+        "@playwright/test": "^1.47.1"
       }
     },
     "../../lib/importer": {
@@ -17,7 +21,7 @@
       "license": "ISC",
       "dependencies": {
         "multer": "^1.4.5-lts.1",
-        "node-xlsx": "^0.24.0"
+        "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz"
       },
       "devDependencies": {
         "jest": "^29.7.0"
@@ -62,6 +66,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.47.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.47.1.tgz",
+      "integrity": "sha512-dbWpcNQZ5nj16m+A5UNScYx7HX5trIy7g4phrcitn+Nk83S32EBX/CLU4hiF4RGKX/yRc93AAqtfaXB7JWBd4Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.47.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@register-dynamics/importer": {
@@ -2553,6 +2573,50 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.47.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.47.1.tgz",
+      "integrity": "sha512-SUEKi6947IqYbKxRiqnbUobVZY4bF1uu+ZnZNJX9DfU1tlf2UhWfvVjLf01pQx9URsOr18bFVUKXmanYWhbfkw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.47.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.47.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.47.1.tgz",
+      "integrity": "sha512-i1iyJdLftqtt51mEk6AhYFaAJCDx0xQ/O5NU8EKaWFgMjItPVma542Nh/Aq8aLCjIJSzjaiEQGW/nyqLkGF1OQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/portscanner": {

--- a/prototypes/basic/package.json
+++ b/prototypes/basic/package.json
@@ -2,12 +2,17 @@
   "scripts": {
     "dev": "govuk-prototype-kit dev",
     "serve": "govuk-prototype-kit serve",
-    "start": "govuk-prototype-kit start"
+    "start": "govuk-prototype-kit start",
+    "test": "npx playwright test"
   },
   "dependencies": {
     "@govuk-prototype-kit/common-templates": "2.0.1",
     "@register-dynamics/importer": "file:../../lib/importer",
     "govuk-frontend": "5.4.1",
-    "govuk-prototype-kit": "13.16.2"
+    "govuk-prototype-kit": "13.16.2",
+    "playwright": "^1.47.1"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.47.1"
   }
 }

--- a/prototypes/basic/playwright.config.js
+++ b/prototypes/basic/playwright.config.js
@@ -2,7 +2,7 @@ import { defineConfig, devices } from '@playwright/test';
 
 export default defineConfig({
     testDir: './tests',
-    reporter: process.env.CI ? ['github', 'junit'] : 'line',
+    reporter: process.env.CI ? [['github'], ['junit', {outputFile: "./test-results/results.xml"}]] : 'line',
     use: {
         baseURL: 'http://127.0.0.1:3000',
     },

--- a/prototypes/basic/playwright.config.js
+++ b/prototypes/basic/playwright.config.js
@@ -2,6 +2,7 @@ import { defineConfig, devices } from '@playwright/test';
 
 export default defineConfig({
     testDir: './tests',
+    reporter: process.env.CI ? ['github', 'junit'] : 'line',
     use: {
         baseURL: 'http://127.0.0.1:3000',
     },

--- a/prototypes/basic/playwright.config.js
+++ b/prototypes/basic/playwright.config.js
@@ -1,0 +1,23 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+    testDir: './tests',
+    use: {
+        // Base URL to use in actions like `await page.goto('/')`.
+        baseURL: 'http://127.0.0.1:3000',
+    },
+    webServer: {
+        command: 'npm run dev',
+        url: 'http://127.0.0.1:3000',
+        reuseExistingServer: !process.env.CI,
+        stdout: 'ignore',
+        stderr: 'pipe',
+      },
+    projects: [
+        {
+            name: 'chromium',
+            use: { ...devices['Desktop Chrome'] },
+            dependencies: [],
+        },
+    ]
+});

--- a/prototypes/basic/playwright.config.js
+++ b/prototypes/basic/playwright.config.js
@@ -2,8 +2,7 @@ import { defineConfig, devices } from '@playwright/test';
 
 export default defineConfig({
     testDir: './tests',
-    reporter: process.env.CI ? [['github'], ['junit', {outputFile: "results.xml"}]] : 'line',
-    outputDir: './test-results',
+    reporter: process.env.CI ? [['github'], ['junit', {outputFile: "./test-results/results.xml"}]] : 'line',
     use: {
         baseURL: 'http://127.0.0.1:3000',
     },

--- a/prototypes/basic/playwright.config.js
+++ b/prototypes/basic/playwright.config.js
@@ -2,7 +2,8 @@ import { defineConfig, devices } from '@playwright/test';
 
 export default defineConfig({
     testDir: './tests',
-    reporter: process.env.CI ? [['github'], ['junit', {outputFile: "./test-results/results.xml"}]] : 'line',
+    reporter: process.env.CI ? [['github'], ['junit', {outputFile: "results.xml"}]] : 'line',
+    outputDir: './test-results',
     use: {
         baseURL: 'http://127.0.0.1:3000',
     },

--- a/prototypes/basic/playwright.config.js
+++ b/prototypes/basic/playwright.config.js
@@ -3,21 +3,13 @@ import { defineConfig, devices } from '@playwright/test';
 export default defineConfig({
     testDir: './tests',
     use: {
-        // Base URL to use in actions like `await page.goto('/')`.
         baseURL: 'http://127.0.0.1:3000',
     },
     webServer: {
         command: 'npm run dev',
         url: 'http://127.0.0.1:3000',
         reuseExistingServer: !process.env.CI,
-        stdout: 'ignore',
+        stdout: 'pipe',
         stderr: 'pipe',
-      },
-    projects: [
-        {
-            name: 'chromium',
-            use: { ...devices['Desktop Chrome'] },
-            dependencies: [],
-        },
-    ]
+      }
 });

--- a/prototypes/basic/tests/helpers/fixtures.js
+++ b/prototypes/basic/tests/helpers/fixtures.js
@@ -1,0 +1,6 @@
+const path = require('node:path');
+
+
+exports.getFixture = (name) => {
+    return path.join(__dirname, "../../../../fixtures", name)
+}

--- a/prototypes/basic/tests/helpers/footer_selector_page.js
+++ b/prototypes/basic/tests/helpers/footer_selector_page.js
@@ -1,0 +1,17 @@
+import { expect } from '@playwright/test';
+
+export class FooterSelectorPage {
+    constructor(page) {
+        this.p = page
+    }
+
+    skip = async() => {
+        await this.p.getByRole('button', { name: 'Skip' }).click();
+    }
+
+
+    submit = async() => {
+        await this.p.getByRole('button', { name: 'Next' }).click();
+    }
+}
+

--- a/prototypes/basic/tests/helpers/header_selector_page.js
+++ b/prototypes/basic/tests/helpers/header_selector_page.js
@@ -1,0 +1,26 @@
+import { expect } from '@playwright/test';
+
+export class HeaderSelectorPage {
+    constructor(page) {
+        this.p = page
+    }
+
+    getTable = async() => {
+        return await this.p.locator("table").nth(0);
+    }
+
+    select = async(start, end) => {
+        let [startRow, startCol] = start;
+        let [endRow, endCol] = end;
+
+        let tbl = await this.getTable()
+        const startCell = await tbl.locator("tbody tr").nth(startRow).locator("td").nth(startCol)
+        const endCell = await tbl.locator("tbody tr").nth(endRow).locator("td").nth(endCol)
+        await startCell.dragTo(endCell)
+    }
+
+    submit = async() => {
+        await this.p.getByRole('button', { name: 'Next' }).click();
+    }
+}
+

--- a/prototypes/basic/tests/helpers/mapping_page.js
+++ b/prototypes/basic/tests/helpers/mapping_page.js
@@ -1,0 +1,48 @@
+import { expect } from '@playwright/test';
+
+export class MappingPage {
+    constructor(page) {
+        this.p = page
+    }
+
+    getTable = async() => {
+        return await this.p.locator('table').nth(0)
+    }
+
+    getColumnNames = async() => {
+        let tbl = await this.getTable()
+        let rowCount = await tbl.locator("tbody tr").count()
+        let names = new Array()
+
+        for (let idx = 0; idx< rowCount; idx++) {
+            let colText = await tbl.locator("tbody tr").nth(idx).locator("th").nth(0).textContent();
+            names.push(colText)
+        }
+
+        return names
+    }
+
+    getExamples = async() => {
+        let tbl = await this.getTable()
+        let rowCount = await tbl.locator("tbody tr").count()
+        let names = new Array()
+
+        for (let idx = 0; idx< rowCount; idx++) {
+            let colText = await tbl.locator("tbody tr").nth(idx).locator("td").nth(0).textContent();
+            names.push(colText)
+        }
+
+        return names
+    }
+
+    setMapping = async(columnName, fieldName) => {
+        let cols = await this.getColumnNames()
+        let idx = cols.findIndex((x)=>x == columnName);
+        await this.p.locator(`[name='${idx}']`).selectOption(fieldName)
+    }
+
+    submit = async() => {
+        await this.p.getByRole('button', { name: 'Submit' }).click();
+    }
+}
+

--- a/prototypes/basic/tests/helpers/sheet_selector_page.js
+++ b/prototypes/basic/tests/helpers/sheet_selector_page.js
@@ -21,8 +21,8 @@ export class SheetSelectorPage {
         );
     }
 
-    getTableData = async(idx) => {
-        return [];
+    getTableRow = async(tableIdx, rowIdx ) => {
+        return await this.p.locator("table").nth(tableIdx).locator("tbody tr").nth(rowIdx)
     }
 
     submit = async() => {

--- a/prototypes/basic/tests/helpers/sheet_selector_page.js
+++ b/prototypes/basic/tests/helpers/sheet_selector_page.js
@@ -1,0 +1,32 @@
+import { expect } from '@playwright/test';
+
+export class SheetSelectorPage {
+    constructor(page) {
+        this.p = page
+    }
+
+    getRadio = async(name) => {
+        return await this.p.getByLabel(name);
+    }
+
+    getTableCount = async() => {
+        return page.locator("table").count
+    }
+
+    getTableProperty = async(idx, propertyName) => {
+        return await this.p.locator("table").nth(idx).evaluate(
+            (el, property) => {
+                return window.getComputedStyle(el).getPropertyValue(property);
+            }, propertyName
+        );
+    }
+
+    getTableData = async(idx) => {
+        return [];
+    }
+
+    submit = async() => {
+        await this.p.getByRole('button', { name: 'Next' }).click();
+    }
+}
+

--- a/prototypes/basic/tests/helpers/upload_page.js
+++ b/prototypes/basic/tests/helpers/upload_page.js
@@ -1,0 +1,16 @@
+import { expect } from '@playwright/test';
+
+export class UploadPage {
+    constructor(page) {
+        this.p = page
+    }
+
+    browseButton = async() => {
+        return await this.p.locator('input[name="file"]')
+    }
+
+    submit = async() => {
+        await this.p.getByRole('button', { name: 'Upload' }).click();
+    }
+}
+

--- a/prototypes/basic/tests/simple.spec.js
+++ b/prototypes/basic/tests/simple.spec.js
@@ -4,5 +4,5 @@ test('has title', async ({ page }) => {
   await page.goto('/');
 
   // Expect a title "to contain" a substring.
-  await expect(page).toHaveTitle(/Import spreadsheet dataaaa/);
+  await expect(page).toHaveTitle(/Import spreadsheet data/);
 });

--- a/prototypes/basic/tests/simple.spec.js
+++ b/prototypes/basic/tests/simple.spec.js
@@ -4,5 +4,5 @@ test('has title', async ({ page }) => {
   await page.goto('/');
 
   // Expect a title "to contain" a substring.
-  await expect(page).toHaveTitle(/Import spreadsheet data/);
+  await expect(page).toHaveTitle(/Import spreadsheet dataaaa/);
 });

--- a/prototypes/basic/tests/simple.spec.js
+++ b/prototypes/basic/tests/simple.spec.js
@@ -1,0 +1,8 @@
+import { test, expect } from '@playwright/test';
+
+test('has title', async ({ page }) => {
+  await page.goto('/');
+
+  // Expect a title "to contain" a substring.
+  await expect(page).toHaveTitle(/Import spreadsheet data/);
+});

--- a/prototypes/basic/tests/tribbles.spec.js
+++ b/prototypes/basic/tests/tribbles.spec.js
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/test';
 
 import { UploadPage } from './helpers/upload_page';
+import { SheetSelectorPage } from './helpers/sheet_selector_page';
 
 
 const path = require('node:path');
@@ -31,18 +32,21 @@ test('trouble with tribbles', async ({ page }) => {
     // Select sheet
     await expect(page).toHaveURL(/.select_sheet/)
 
-    await page.getByLabel('My lovely tribbles').check();
-    expect(page.getByLabel('My lovely tribbles')).toBeChecked();
+    const sheets = new SheetSelectorPage(page);
+
+    const radioButton = await sheets.getRadio('My lovely tribbles')
+    await radioButton.check()
+    expect(radioButton).toBeChecked();
 
     // Check sheet preview visibility, we only expect one to be shown
     for (let [idx, expected] of sheetPreviewVisibility) {
-        let hiddenTableDisplay = await page.locator("table").nth(idx).evaluate((el) => {
-            return window.getComputedStyle(el).getPropertyValue('visibility');
-        });
-        expect(hiddenTableDisplay).toBe(expected)
+        expect(await sheets.getTableProperty(idx, 'visibility')).toBe(expected)
     }
 
     // Check the data is present in the sheet previews
+    const data = sheets.getTableData(1)
+
+
     const tbl = await page.locator("table").nth(1);
     const firstCell = await tbl.locator("tbody tr").nth(0).locator("td").nth(0).textContent()
     expect(firstCell).toBe("My lovely tribbles")

--- a/prototypes/basic/tests/tribbles.spec.js
+++ b/prototypes/basic/tests/tribbles.spec.js
@@ -44,13 +44,11 @@ test('trouble with tribbles', async ({ page }) => {
     }
 
     // Check the data is present in the sheet previews
-    const data = sheets.getTableData(1)
-
-
-    const tbl = await page.locator("table").nth(1);
-    const firstCell = await tbl.locator("tbody tr").nth(0).locator("td").nth(0).textContent()
+    const previewRow = await sheets.getTableRow(1, 0)
+    const firstCell = await previewRow.locator("td").nth(0).textContent()
     expect(firstCell).toBe("My lovely tribbles")
-    await page.getByRole('button', { name: 'Next' }).click();
+
+    await sheets.submit()
 
     // ---------------------------------------------------------------------------
     // Select some cells for a header row

--- a/prototypes/basic/tests/tribbles.spec.js
+++ b/prototypes/basic/tests/tribbles.spec.js
@@ -4,7 +4,8 @@ import * as fixtures from "./helpers/fixtures";
 
 import { UploadPage } from './helpers/upload_page';
 import { SheetSelectorPage } from './helpers/sheet_selector_page';
-
+import { HeaderSelectorPage } from './helpers/header_selector_page';
+import { FooterSelectorPage } from './helpers/footer_selector_page'
 
 const path = require('node:path');
 
@@ -13,6 +14,11 @@ const sheetPreviewVisibility = new Map([
     [1, "visible"],
     [2, "hidden"]
 ]);
+
+// Take a screenshot to help with debugging
+const screenshot = async(page, name) => {
+    await page.screenshot({ path: name, fullPage: true });
+}
 
 test('trouble with tribbles', async ({ page }) => {
     await page.goto('/');
@@ -56,17 +62,16 @@ test('trouble with tribbles', async ({ page }) => {
     // We will use Name->Markings as our selection
     await expect(page).toHaveURL(/.select_header_row/)
 
-    const headerTbl = await page.locator("table").nth(0);
-    const startCell = await headerTbl.locator("tbody tr").nth(2).locator("td").nth(0)
-    const endCell = await headerTbl.locator("tbody tr").nth(2).locator("td").nth(5)
-    await startCell.dragTo(endCell)
-    await page.getByRole('button', { name: 'Next' }).click();
+    const headers = new HeaderSelectorPage(page)
+    await headers.select([2,0], [2,5])
+    await headers.submit()
 
     // ---------------------------------------------------------------------------
     // Do not choose a footer row, just click Skip
     await expect(page).toHaveURL(/.select_footer_row/)
 
-    await page.getByRole('button', { name: 'Skip' }).click();
+    const footers = new FooterSelectorPage(page)
+    await footers.skip()
 
     // ---------------------------------------------------------------------------
     // Perform the mapping after checking the previews here are what we expect

--- a/prototypes/basic/tests/tribbles.spec.js
+++ b/prototypes/basic/tests/tribbles.spec.js
@@ -1,0 +1,100 @@
+import { test, expect } from '@playwright/test';
+
+const path = require('node:path');
+
+const sheetPreviewVisibility = new Map([
+    [0, "hidden"],
+    [1, "visible"],
+    [2, "hidden"]
+]);
+
+test('trouble with tribbles', async ({ page }) => {
+    await page.goto('/');
+    await page.getByText('Start now').click();
+    await expect(page).toHaveURL(/.upload/)
+
+    // ---------------------------------------------------------------------------
+    // Upload a file
+    const tribblesFile = path.join(__dirname, "../../../fixtures", 'tribbles.xlsx')
+    await page.locator('input[name="file"]').click();
+    await page.locator('input[name="file"]').setInputFiles(tribblesFile);
+    await page.getByRole('button', { name: 'Upload' }).click();
+
+    // ---------------------------------------------------------------------------
+    // Select sheet
+    await expect(page).toHaveURL(/.select_sheet/)
+
+    await page.getByLabel('My lovely tribbles').check();
+    expect(page.getByLabel('My lovely tribbles')).toBeChecked();
+
+    // Check sheet preview visibility, we only expect one to be shown
+    for (let [idx, expected] of sheetPreviewVisibility) {
+        let hiddenTableDisplay = await page.locator("table").nth(idx).evaluate((el) => {
+            return window.getComputedStyle(el).getPropertyValue('visibility');
+        });
+        expect(hiddenTableDisplay).toBe(expected)
+    }
+
+    // Check the data is present in the sheet previews
+    const tbl = await page.locator("table").nth(1);
+    const firstCell = await tbl.locator("tbody tr").nth(0).locator("td").nth(0).textContent()
+    expect(firstCell).toBe("My lovely tribbles")
+    await page.getByRole('button', { name: 'Next' }).click();
+
+    // ---------------------------------------------------------------------------
+    // Select some cells for a header row
+    // We will use Name->Markings as our selection
+    await expect(page).toHaveURL(/.select_header_row/)
+
+    const headerTbl = await page.locator("table").nth(0);
+    const startCell = await headerTbl.locator("tbody tr").nth(2).locator("td").nth(0)
+    const endCell = await headerTbl.locator("tbody tr").nth(2).locator("td").nth(5)
+    await startCell.dragTo(endCell)
+    await page.getByRole('button', { name: 'Next' }).click();
+
+    // ---------------------------------------------------------------------------
+    // Do not choose a footer row, just click Skip
+    await expect(page).toHaveURL(/.select_footer_row/)
+
+    await page.getByRole('button', { name: 'Skip' }).click();
+
+    // ---------------------------------------------------------------------------
+    // Perform the mapping after checking the previews here are what we expect
+    await expect(page).toHaveURL(/.mapping/)
+
+    const expectedColumns = ["Name", "Date of birth", "Time of birth", "Weight", "Colour", "Markings"]
+    const expectedExamples = new Map([
+        [0, "Alex, Drew, Emm, Jamie, Kris"],
+        [4, "Beige, Black, Brown, Maroon, Pink"],
+        [5, "Blob on top, N/A, Splotches, Yes,"],
+    ])
+
+    const mappingTbl = await page.locator("table").nth(0)
+
+    // Check the columns names (these are the headers we selected previously)
+    let rowCount = await mappingTbl.locator("tbody tr").count()
+    for(;rowCount>0;rowCount--) {
+        let index = rowCount - 1;
+
+        // First cell is a th not a td
+        let colText = await mappingTbl.locator("tbody tr").nth(index).locator("th").nth(0).textContent();
+        expect(expectedColumns.pop()).toBe(colText)
+
+        if (expectedExamples.has(index)) {
+            let exampleText = await mappingTbl.locator("tbody tr").nth(index).locator("td").nth(0).textContent();
+            expect(exampleText).toBe(expectedExamples.get(index))
+        }
+    }
+    expect(expectedColumns).toStrictEqual([])
+
+    // Single selection matching the value or label
+    await page.locator("[name='0']").selectOption("Code")
+    await page.locator("[name='4']").selectOption("Name")
+    await page.locator("[name='5']").selectOption("Speciality")
+
+    await page.getByRole('button', { name: 'Submit' }).click();
+
+    // ---------------------------------------------------------------------------
+    // Should be on the success page
+    await expect(page).toHaveURL(/.success/)
+});

--- a/prototypes/basic/tests/tribbles.spec.js
+++ b/prototypes/basic/tests/tribbles.spec.js
@@ -1,5 +1,8 @@
 import { test, expect } from '@playwright/test';
 
+import { UploadPage } from './helpers/upload_page';
+
+
 const path = require('node:path');
 
 const sheetPreviewVisibility = new Map([
@@ -11,14 +14,18 @@ const sheetPreviewVisibility = new Map([
 test('trouble with tribbles', async ({ page }) => {
     await page.goto('/');
     await page.getByText('Start now').click();
-    await expect(page).toHaveURL(/.upload/)
 
     // ---------------------------------------------------------------------------
     // Upload a file
+    await expect(page).toHaveURL(/.upload/)
+
     const tribblesFile = path.join(__dirname, "../../../fixtures", 'tribbles.xlsx')
-    await page.locator('input[name="file"]').click();
-    await page.locator('input[name="file"]').setInputFiles(tribblesFile);
-    await page.getByRole('button', { name: 'Upload' }).click();
+    const uploadPage = new UploadPage(page)
+    const browseButton = await uploadPage.browseButton()
+
+    await browseButton.click();
+    await browseButton.setInputFiles(tribblesFile);
+    await uploadPage.submit();
 
     // ---------------------------------------------------------------------------
     // Select sheet

--- a/prototypes/basic/tests/tribbles.spec.js
+++ b/prototypes/basic/tests/tribbles.spec.js
@@ -1,5 +1,7 @@
 import { test, expect } from '@playwright/test';
 
+import * as fixtures from "./helpers/fixtures";
+
 import { UploadPage } from './helpers/upload_page';
 import { SheetSelectorPage } from './helpers/sheet_selector_page';
 
@@ -20,12 +22,11 @@ test('trouble with tribbles', async ({ page }) => {
     // Upload a file
     await expect(page).toHaveURL(/.upload/)
 
-    const tribblesFile = path.join(__dirname, "../../../fixtures", 'tribbles.xlsx')
     const uploadPage = new UploadPage(page)
     const browseButton = await uploadPage.browseButton()
 
     await browseButton.click();
-    await browseButton.setInputFiles(tribblesFile);
+    await browseButton.setInputFiles(fixtures.getFixture('tribbles.xlsx'));
     await uploadPage.submit();
 
     // ---------------------------------------------------------------------------


### PR DESCRIPTION
Adds playwright to the basic prototype so that we can test the prototype where components are built and tested.  Currently only tests the happy path using tribbles.xlsx, but provides the foundation for further testing.  Does not yet test new prototype creation, this will be done as a separate PR