### PR TITLE
Add a link from static docs to plugin docs

### DIFF
--- a/lib/importer/assets/docs/start.html
+++ b/lib/importer/assets/docs/start.html
@@ -69,8 +69,10 @@
             <div data-static-only>
                 <p>Install the plugin by typing:</p>
                 <pre>npm install 'https://gitpkg.vercel.app/register-dynamics/data-import/lib/importer?main'</pre>
-                <p>Then run the Prototype Kit and visit the "Manage Prototype" section to get help on
-                    using the Importer.</p>
+                <p>Then run the Prototype Kit and visit <a
+                        href="http://localhost:3000/plugin-assets/%40register-dynamics%2Fimporter/assets/docs/start.html">the
+                        internal documentation</a>
+                    to get help using the Data Design Kit.</p>
             </div>
             <p data-plugin-only class="govuk-body">
                 <span class="govuk-tag govuk-tag--green">Installed</span>


### PR DESCRIPTION
We found during testing that trying to explain to users how to get to the internal docs didn't really work. Instead lets try a link that only works if the PK is running.