### PR TITLE
Automatically install the plugin router

### DIFF
--- a/lib/importer/assets/docs/start.html
+++ b/lib/importer/assets/docs/start.html
@@ -74,13 +74,9 @@
                 <span class="govuk-tag govuk-tag--green">Installed</span>
                 You have already installed the plugin and it is ready to be used in this prototype.
             </p>
-            <p>Now add these lines to the bottom of <code>app/routes.js</code> to configure the
-                prototype to receive and
-                process
-                spreadsheets:
-            <pre>const importer = require("@register-dynamics/importer");
-const cfg = require("govuk-prototype-kit/lib/config");
-importer.Initialise(cfg.getConfig(), router, govukPrototypeKit);</pre>
+            <p>Installing the plugin will automatically append lines to your
+                <code>app/routes.js</code> file to configure the prototype to
+                receive and process spreadsheets.
             </p>
             <h2 class="govuk-heading-l">Configuration</h2>
             <p>Finally, add some fields to <code>app/config.json</code> that the user will be asked for

--- a/lib/importer/package.json
+++ b/lib/importer/package.json
@@ -12,7 +12,8 @@
   },
   "main": "index.js",
   "scripts": {
-    "test": "jest"
+    "test": "jest",
+    "postinstall": "node ./scripts/install-router.js"
   },
   "author": "",
   "license": "ISC",

--- a/lib/importer/scripts/install-router.js
+++ b/lib/importer/scripts/install-router.js
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+
+const fs = require("fs")
+const path = require("path")
+
+const requiredLines = [
+    `const importer = require("@register-dynamics/importer");`,
+    `const cfg = require("govuk-prototype-kit/lib/config");`,
+    `importer.Initialise(cfg.getConfig(), router, govukPrototypeKit);\n`
+]
+
+const optionalLines = [
+    `\n\n// Below ${requiredLines.length} lines added by the Data Design Kit plugin.`,
+    `// If you uninstall the plugin, remove the ${requiredLines.length} lines below.`
+]
+
+const routesFilename = path.join(process.env.INIT_CWD, "app", "routes.js")
+if (!fs.existsSync(routesFilename)) return
+
+const routesFile = fs.readFileSync(routesFilename, {encoding: "utf-8"})
+const looksLikePrototypeKit = routesFile.includes("govukPrototypeKit")
+const containsRequiredLines = requiredLines.find(line => !routesFile.includes(line)) === undefined
+if (looksLikePrototypeKit && !containsRequiredLines) {
+    console.info(`Patching ${routesFilename}`)
+    fs.appendFileSync(routesFilename, [...optionalLines, ...requiredLines].join("\n"))
+}

--- a/prototypes/basic/app/routes.js
+++ b/prototypes/basic/app/routes.js
@@ -5,7 +5,9 @@
 const govukPrototypeKit = require("govuk-prototype-kit");
 const router = govukPrototypeKit.requests.setupRouter();
 
-const cfg = require("govuk-prototype-kit/lib/config");
-const importer = require("@register-dynamics/importer");
 
+// Below 3 lines added by the Data Design Kit plugin.
+// If you uninstall the plugin, remove the 3 lines below.
+const importer = require("@register-dynamics/importer");
+const cfg = require("govuk-prototype-kit/lib/config");
 importer.Initialise(cfg.getConfig(), router, govukPrototypeKit);


### PR DESCRIPTION
Here we use a postinstall hook to automatically add the required router lines to the app/routes.js, if it exists. We check first that this looks like a Prototype Kit prototype and not some other app.

Unfortunately we can't automatically reverse this process because npm doesn't run the pre/postuninstall hooks of dependent packages, because it sucks.