### PR TITLE
When ctrl-clicking to select multiple cells, use cmd on mac

### DIFF
--- a/lib/importer/assets/js/selectable_table.js
+++ b/lib/importer/assets/js/selectable_table.js
@@ -1,4 +1,18 @@
+const get_platform = () =>  {
+  // userAgentData is not widely supported yet
+  if (typeof navigator.userAgentData !== 'undefined' && navigator.userAgentData != null) {
+      return navigator.userAgentData.platform;
+  }
+  // Currently deprecated
+  if (typeof navigator.platform !== 'undefined') {
+      return navigator.platform;
+  }
+  return 'unknown';
+}
+
 window.addEventListener("load", function() {
+    const isMac = /mac/i.test(get_platform())
+
     const CellSelectedClassName = "selected";
     const CellSelectedBottomClassName = "bottom";
     const CellSelectedTopClassName = "top";
@@ -833,6 +847,7 @@ window.addEventListener("load", function() {
         updateKey(keyEvent.shiftKey, "Shift");
         updateKey(keyEvent.ctrlKey, "Control");
         updateKey(keyEvent.altKey, "Alt");
+        updateKey(keyEvent.metaKey, "Meta");
       }
 
       DocumentSelectMode.addEvent("keydown", updateFromKeyEvent);
@@ -855,7 +870,9 @@ window.addEventListener("load", function() {
         // If we have control-dragged, add the new selection to the existing selection
         // Otherwise, replace the existing selection with the new one
         const mergeSelection = function(newSelection) {
-          if (depressedKeys.has("Control")) {
+          const selectionKey = isMac ? "Meta" : "Control"
+
+          if (depressedKeys.has(selectionKey)) {
             return initialSelection.includingSelection(newSelection);
           } else {
             return newSelection;


### PR DESCRIPTION
If we use ctrl with the click when selecting multiple cells, it shows the context menu. Instead, we use the Command key (meta) when we have detected we're on a mac.