### PR TITLE
Update makefile to simplify updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,21 @@
 
+update-deps:
+	@echo "***************************"
+	@echo "** Updating importer lib **"
+	@echo "***************************"
+	@cd lib/importer && npm install
+	@echo "***********************************"
+	@echo "** Default development prototype **"
+	@echo "***********************************"
+	@cd prototypes/basic && npm install
+
 
 .PHONY: prototype
-prototype:
 ifndef NAME
-    $(error Need a value for NAME, e.g., make prototype NAME=value)
-endif
+prototype:
+	$(error Need a value for NAME, e.g., make prototype NAME=value)
+else
+prototype:
 	@cd lib/importer && npm install
 	@mkdir -p prototypes/${NAME}
 	@cd prototypes/${NAME} && npx govuk-prototype-kit@latest create && npm install ../../lib/importer
@@ -17,3 +28,5 @@ endif
 	    cd prototypes/${NAME}\n\
 	    npm run dev\n\
 	"
+endif
+

--- a/prototypes/basic/package-lock.json
+++ b/prototypes/basic/package-lock.json
@@ -25,8 +25,8 @@
         "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz"
       },
       "devDependencies": {
-        "@eslint/js": "^9.12.0",
-        "eslint": "^9.12.0",
+        "@eslint/js": "^9.13.0",
+        "eslint": "^9.14.0",
         "eslint-plugin-jest": "^28.8.3",
         "globals": "^15.11.0",
         "jest": "^29.7.0"
@@ -83,50 +83,6 @@
       },
       "bin": {
         "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@playwright/test/node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/@playwright/test/node_modules/playwright": {
-      "version": "1.47.2",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.47.2.tgz",
-      "integrity": "sha512-nx1cLMmQWqmA3UsnjaaokyoUpdVaaDhJhMoxX2qj3McpjnsqFHs516QAKYhqHAgOP+oCFTEOCOAaD1RgD/RQfA==",
-      "dev": true,
-      "dependencies": {
-        "playwright-core": "1.47.2"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
-      }
-    },
-    "node_modules/@playwright/test/node_modules/playwright-core": {
-      "version": "1.47.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.47.2.tgz",
-      "integrity": "sha512-3JvMfF+9LJfe16l7AbSmU555PaTl2tPyQsVInqm3id16pdDfvZ8TTZ/pyzmkbDrZTQefyzU7AIHlZqQnxpqHVQ==",
-      "dev": true,
-      "bin": {
-        "playwright-core": "cli.js"
       },
       "engines": {
         "node": ">=18"


### PR DESCRIPTION
To make it easier to update dependencies when dependabot submits a new update, this adds a new target `update-deps` which will update the importer and the development prototype.

To make this work, had to restructure the `prototype` target so that it doesn't complain for other targets when `NAME=` is missing.