### PR TITLE
Show upload preview without error

### DIFF
--- a/lib/importer/templates/previews/upload.html
+++ b/lib/importer/templates/previews/upload.html
@@ -1,0 +1,24 @@
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/file-upload/macro.njk" import govukFileUpload %}
+
+{% macro show() %}
+<div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">Upload your data</h1>
+
+    <form method="POST" enctype="multipart/form-data">
+        <div>
+            {{ govukFileUpload({
+                id: "file-upload",
+                name: "file",
+                label: { text: "Upload an XLSX, ODS, or CSV file"},
+                attributes: { "accept":
+                ".xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.csv,text/csv,application/vnd.oasis.opendocument.spreadsheet,.ods"},
+                errorMessage: false })
+            }}
+        </div>
+        <div class="govuk-button-group">
+            {{ govukButton({ text: "Upload" }) }}
+        </div>
+    </form>
+</div>
+{% endmacro %}

--- a/lib/importer/templates/upload.html
+++ b/lib/importer/templates/upload.html
@@ -4,31 +4,36 @@
 
 {% block pageTitle %} {{ serviceName }} – GOV.UK Prototype Kit {% endblock %}
 {% block beforeContent %}
-{{ govukBackLink({ text: "Back", href: "javascript:window.history.back()" }) }}
+    {{ govukBackLink({ text: "Back", href: "javascript:window.history.back()" }) }}
 {% endblock %}
 
 {% block content %}
 <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-        <h1 class="govuk-heading-l">Upload your data</h1>
+    {% if importerUploadPath %}
+        <div class="govuk-grid-column-two-thirds">
+            <h1 class="govuk-heading-l">Upload your data</h1>
 
-        <form action="{{importerUploadPath('/select_sheet')}}" method="POST" enctype="multipart/form-data">
-            <div>
-                {{ govukFileUpload({
-                id: "file-upload",
-                name: "file",
-                label: { text: "Upload an XLSX, ODS, or CSV file"},
-                attributes: { "accept": ".xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.csv,text/csv,application/vnd.oasis.opendocument.spreadsheet,.ods"},
-                errorMessage: importerError(data)
-                })
-                }}
-            </div>
-            <div class="govuk-button-group">
-                {{ govukButton({ text: "Upload" }) }}
-            </div>
-        </form>
-    </div>
+            <form action="{{importerUploadPath('/select_sheet')}}" method="POST" enctype="multipart/form-data">
+                <div>
+                    {{
+                        govukFileUpload({
+                            id: "file-upload",
+                            name: "file",
+                            label: { text: "Upload an XLSX, ODS, or CSV file"},
+                            attributes: { "accept":
+                            ".xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.csv,text/csv,application/vnd.oasis.opendocument.spreadsheet,.ods"},
+                            errorMessage: importerError(data)
+                        })
+                    }}
+                </div>
+                <div class="govuk-button-group">
+                    {{ govukButton({ text: "Upload" }) }}
+                </div>
+            </form>
+        </div>
+    {% else %}
+        {% import "./previews/upload.html" as preview %}
+        {{ preview.show() }}
+    {% endif %}
 </div>
-
-
 {% endblock %}


### PR DESCRIPTION
Adds a new macro which will show the upload form without relying on any macros that are not installed because we are showing the preview by just showing the template on the page.

As a result the preview.show() macro needs to import all of the govuk components (which are not installed in the importer, but will be when showing the preview) for any govuk components.

Unfortunately, when installing this template, it will keep the block that decides to show the preview and will likely generate support questions around its presence.

This PR is just to show the result of attempting this approach to fix #63 