### PR TITLE
Add tests to check config modifications are persisted.

### DIFF
--- a/lib/importer/package-lock.json
+++ b/lib/importer/package-lock.json
@@ -19,7 +19,8 @@
         "eslint": "^9.19.0",
         "eslint-plugin-jest": "^28.11.0",
         "globals": "^15.14.0",
-        "jest": "^29.7.0"
+        "jest": "^29.7.0",
+        "mock-fs": "^5.5.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -4032,6 +4033,16 @@
       },
       "bin": {
         "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/mock-fs": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-5.5.0.tgz",
+      "integrity": "sha512-d/P1M/RacgM3dB0sJ8rjeRNXxtapkPCUnMGmIN0ixJ16F/E4GUZCvWcSGfWGz8eaXYvn1s9baUwNjI4LOPEjiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/ms": {

--- a/lib/importer/package.json
+++ b/lib/importer/package.json
@@ -29,6 +29,7 @@
     "eslint": "^9.19.0",
     "eslint-plugin-jest": "^28.11.0",
     "globals": "^15.14.0",
+    "mock-fs": "^5.5.0",
     "jest": "^29.7.0"
   }
 }

--- a/lib/importer/src/config.test.js
+++ b/lib/importer/src/config.test.js
@@ -1,0 +1,107 @@
+var assert = require('assert');
+const cfg = require('./config');
+const fs = require('node:fs');
+const mock_files = require('mock-fs');
+
+
+describe("Configuration tests", () => {
+
+    test('initial empty config', () => {
+        mock_files({
+            './empty/app/config.json': '{}'
+        })
+
+        withCurrent(
+            "./empty",
+            new cfg.PluginConfig(),
+            (c) => {
+                c.setFields(["A"])
+            },
+            (original, updated, c) => {
+                expect(original.fields).toBeUndefined()
+                expect(updated.fields).toStrictEqual(["A"])
+                expect(c.fields).toStrictEqual(["A"])
+
+                // We expect a non-null value by default, but can't construct something
+                // to compare against as the tmp directory given may be different on
+                // each call
+                expect(original.uploadPath).not.toBeNull()
+                expect(updated.uploadPath).not.toBeNull()
+                expect(c.uploadPath).not.toBeNull()
+            }
+        );
+
+        mock_files.restore();
+    });
+
+    test('existing fields', () => {
+        mock_files({
+            './fields/app/config.json': '{"fields": ["A", "B", "C"]}',
+        })
+
+        withCurrent(
+            "./fields",
+            new cfg.PluginConfig(),
+            (c) => {
+                c.setFields(["A", "B"])
+            },
+            (original, updated, c) => {
+                expect(original.fields).toStrictEqual(["A", "B", "C"])
+                expect(updated.fields).toStrictEqual(["A", "B"])
+                expect(c.fields).toStrictEqual(["A", "B"])
+            }
+        );
+
+        mock_files.restore();
+    });
+
+    test('existing path', () => {
+        mock_files({
+            './path/app/config.json': '{"uploadPath": "/tmp"}',
+        })
+
+        withCurrent(
+            "./path",
+            new cfg.PluginConfig(),
+            (c) => {
+                c.setUploadPath("/opt")
+            },
+            (original, updated, c) => {
+                expect(original.uploadPath).toBe("/tmp")
+                expect(updated.uploadPath).toBe("/opt")
+                expect(c.uploadPath).toBe("/opt")
+            }
+        );
+
+        mock_files.restore();
+    });
+
+})
+
+
+// withCurrent is a helper function which is used to load a plugin config
+// apply some changes, and then assert the expectations of the state.
+//
+//      rootFolder is the folder where the `app/config.json` can
+//      be found in this test.
+//
+//      pluginConfig is a newly constructed PluginConfig
+//
+//      cbFunction is a callback function that will be given the
+//      plugin configuration so that changes can be made via its API.
+//
+//      assertionsFunc is a function that is provided with:
+//          * the original json object (before cbFunction was called)
+//          * the new json object post-cbFunction
+//          * the pluginConfig that was modified by cbFunction
+function withCurrent(rootFolder, pluginConfig, cbFunction, assertionsFunc) {
+    assert(typeof (cbFunction) === 'function')
+    assert(typeof (assertionsFunc) === 'function')
+
+    process.env.KIT_PROJECT_DIR = rootFolder
+
+    const original = JSON.parse(fs.readFileSync(pluginConfig.configPath, 'utf8'));
+    cbFunction(pluginConfig)
+    const updated = JSON.parse(fs.readFileSync(pluginConfig.configPath, 'utf8'));
+    assertionsFunc(original, updated, pluginConfig)
+}

--- a/prototypes/basic/package-lock.json
+++ b/prototypes/basic/package-lock.json
@@ -21,6 +21,7 @@
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
+        "fs-extra": "3.0.1",
         "multer": "^1.4.5-lts.1",
         "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz"
       },
@@ -29,7 +30,8 @@
         "eslint": "^9.19.0",
         "eslint-plugin-jest": "^28.11.0",
         "globals": "^15.14.0",
-        "jest": "^29.7.0"
+        "jest": "^29.7.0",
+        "mock-fs": "^5.5.0"
       }
     },
     "node_modules/@govuk-prototype-kit/common-templates": {


### PR DESCRIPTION
When updating the configuration object, we want to make sure changes are persisted to disk so this commit adds tests to check that functionality does what is expected.