### PR TITLE
Add pages to manage configuration

### DIFF
--- a/lib/importer/src/config.js
+++ b/lib/importer/src/config.js
@@ -15,6 +15,8 @@ const fse = require("fs-extra");
 const path = require("node:path");
 const os = require("node:os");
 
+const TEMP_DIRECTORY_LABEL = "[Temporary directory]"
+
 exports.PluginConfig = class {
   constructor(config = {}) {
     this.fields = config.fields || [];
@@ -45,14 +47,24 @@ exports.PluginConfig = class {
 
   setFields = (fields) => {
     this.fields = fields;
-    this.persistConfig();
   };
 
-  setUploadPath = (path) => {
-    this.uploadPath = path;
-    this.uploadPathDefault = false;
-    this.persistConfig();
+  setUploadPath = (newPath) => {
+    if (newPath == null || newPath == "") {
+      this.uploadPath = path.join(os.tmpdir(), "reg-dyn-importer");
+      this.uploadPathDefault = true;
+    } else {
+      this.uploadPath = newPath;
+      this.uploadPathDefault = false;
+    }
   };
+
+  as_object = () => {
+    return {
+      uploadPath: this.uploadPathDefault ? TEMP_DIRECTORY_LABEL : this.uploadPath,
+      fields: this.fields
+    }
+  }
 
   //--------------------------------------------------------------------
   // Save the current data importer values into the existing and
@@ -65,11 +77,7 @@ exports.PluginConfig = class {
     let current = fse.readJsonSync(configFilePath);
 
     current.fields = this.fields;
-
-    // Only update the upload path if we have a value that is not the default
-    if (!this.uploadPathDefault) {
-      current.uploadPath = this.uploadPath;
-    }
+    current.uploadPath = this.uploadPath;
 
     fse.writeJsonSync(configFilePath, current);
   };

--- a/lib/importer/src/config.test.js
+++ b/lib/importer/src/config.test.js
@@ -16,6 +16,7 @@ describe("Configuration tests", () => {
             new cfg.PluginConfig(),
             (c) => {
                 c.setFields(["A"])
+                c.persistConfig()
             },
             (original, updated, c) => {
                 expect(original.fields).toBeUndefined()
@@ -44,6 +45,7 @@ describe("Configuration tests", () => {
             new cfg.PluginConfig(),
             (c) => {
                 c.setFields(["A", "B"])
+                c.persistConfig()
             },
             (original, updated, c) => {
                 expect(original.fields).toStrictEqual(["A", "B", "C"])
@@ -65,6 +67,7 @@ describe("Configuration tests", () => {
             new cfg.PluginConfig(),
             (c) => {
                 c.setUploadPath("/opt")
+                c.persistConfig()
             },
             (original, updated, c) => {
                 expect(original.uploadPath).toBe("/tmp")

--- a/lib/importer/src/index.js
+++ b/lib/importer/src/index.js
@@ -586,6 +586,37 @@ exports.Initialise = (config, router, prototypeKit) => {
         response.redirect(IMPORTER_ROUTE_MAP.get("importerConfiguration"))
       }
     )
+
+    // Render the add a field page
+    router.get(
+      IMPORTER_ROUTE_MAP.get("importerConfigurationField"),
+      (request, response) => {
+        render_add_field(response)
+      }
+    );
+
+    // Add or delete a field based on the action supplied by the form
+    router.post(
+      IMPORTER_ROUTE_MAP.get("importerConfigurationField"),
+      (request, response) => {
+        if (!request.body.field) {
+          render_add_field(response, "Missing value", "You must provide a name for the field using only alphanumeric characters or whitespace")
+          return
+        }
+
+        if (request.body.action == "delete") {
+          plugin_config.setFields(plugin_config.fields.filter((x) => x != request.body.field))
+        } else {
+          // We don't want to add a field if it already exists (by name), and so we will
+          // just return if it is already included.
+          if (!plugin_config.fields.find((x) => x.toUpperCase() == request.body.field.toUpperCase())) {
+            plugin_config.setFields([...plugin_config.fields, request.body.field])
+          }
+        }
+
+        response.redirect(IMPORTER_ROUTE_MAP.get("importerConfiguration"));
+      }
+    );
   } else {
     // Disable all handling for configuration pages when not in development mode
     router.all(
@@ -607,36 +638,6 @@ exports.Initialise = (config, router, prototypeKit) => {
     }
   }
 
-  // Render the add a field page
-  router.get(
-    IMPORTER_ROUTE_MAP.get("importerConfigurationField"),
-    (request, response) => {
-      render_add_field(response)
-    }
-  );
-
-  // Add or delete a field based on the action supplied by the form
-  router.post(
-    IMPORTER_ROUTE_MAP.get("importerConfigurationField"),
-    (request, response) => {
-      if (!request.body.field) {
-        render_add_field(response, "Missing value", "You must provide a name for the field using only alphanumeric characters or whitespace")
-        return
-      }
-
-      if (request.body.action == "delete") {
-        plugin_config.setFields(plugin_config.fields.filter((x) => x != request.body.field))
-      } else {
-        // We don't want to add a field if it already exists (by name), and so we will
-        // just return if it is already included.
-        if (!plugin_config.fields.find((x) => x.toUpperCase() == request.body.field.toUpperCase())) {
-          plugin_config.setFields([...plugin_config.fields, request.body.field])
-        }
-      }
-
-      response.redirect(IMPORTER_ROUTE_MAP.get("importerConfiguration"));
-    }
-  );
 
   //--------------------------------------------------------------------
   // Review the processing for the current session before continuing.

--- a/lib/importer/src/index.js
+++ b/lib/importer/src/index.js
@@ -1,5 +1,6 @@
 const multer = require("multer");
 const conf = require("./config.js");
+const fs = require("node:fs");
 const path = require("node:path");
 const session_lib = require("./session.js");
 const sheets_lib = require("./sheets.js");
@@ -21,7 +22,8 @@ const IMPORTER_ROUTE_MAP = new Map([
   ["importerSelectHeaderPath", "/importer/header_selection"],
   ["importerSelectFooterPath", "/importer/footer_selection"],
   ["importerConfiguration", "/importer/config"],
-  ["importerConfigurationField", "/importer/config/field"]
+  ["importerConfigurationField", "/importer/config/field"],
+  ["importerConfigurationPath", "/importer/config/path"]
 ]);
 
 exports.Initialise = (config, router, prototypeKit) => {
@@ -511,21 +513,91 @@ exports.Initialise = (config, router, prototypeKit) => {
   // Configuration management routes.
   //--------------------------------------------------------------------
 
+  const TEMP_DIRECTORY_LABEL = "[Temporary directory]"
+
   // Render the config page
   router.get(
     IMPORTER_ROUTE_MAP.get("importerConfiguration"),
     (request, response) => {
+      const pc = {
+        config: {
+          fields: plugin_config.fields,
+          uploadPath: plugin_config.uploadPathDefault ? TEMP_DIRECTORY_LABEL : plugin_config.uploadPath
+        }
+      }
+
+      // Copy flash message to template object and then remove from memory
+      if (request.session.data['internal-message']) {
+        pc.message = request.session.data['internal-message']
+        request.session.data['internal-message'] = null
+      }
+
+      // This is a bit of a hacky way to render the error in the GET counterpart to a
+      // previous POST request at this URL.
+      if (request.session.data['internal-error']) {
+        pc.error_summary = request.session.data['internal-error'].summary
+        pc.error = request.session.data['internal-error'].error
+        pc.config.uploadPath = request.session.data['internal-error'].parameter
+        request.session.data['internal-error'] = null
+      }
+
       response.status(200)
-      response.render("plugin_config.html", { "config": plugin_config })
+      response.render("plugin_config.html", pc)
     }
   );
+
+
+  router.post(
+    IMPORTER_ROUTE_MAP.get("importerConfiguration"),
+    (request, response) => {
+      request.session.data['internal-message'] = "Configuration changes have been saved, and the application will restart shortly"
+
+      setTimeout(function () {
+        plugin_config.persistConfig()
+      }, 5000)
+
+      response.redirect(IMPORTER_ROUTE_MAP.get("importerConfiguration"))
+    }
+  );
+
+  router.post(
+    IMPORTER_ROUTE_MAP.get("importerConfigurationPath"),
+    (request, response) => {
+      let newPath = request.body.uploadPath
+
+      if (newPath && !fs.existsSync(newPath)) {
+        request.session.data['internal-error'] = {
+          summary: "Directory does not exists",
+          error: "The specified path does not exist on the computer where the prototype kit is executing. Please choose another path or set to empty for the default value. The plugin will not operate until this error is corrected",
+          parameter: newPath
+        }
+        response.redirect(IMPORTER_ROUTE_MAP.get("importerConfiguration"))
+        return
+      }
+
+      plugin_config.setUploadPath(newPath)
+
+      response.redirect(IMPORTER_ROUTE_MAP.get("importerConfiguration"))
+    }
+  )
+
+
+
+  function render_add_field(res, summary, error) {
+    if (summary) {
+      res.status(400)
+      res.render("plugin_config_add_field.html", { error: error, error_summary: summary })
+    } else {
+      res.status(200)
+      res.render("plugin_config_add_field.html")
+    }
+  }
 
   // Render the add a field page
   router.get(
     IMPORTER_ROUTE_MAP.get("importerConfigurationField"),
     (request, response) => {
-      response.status(200)
-      response.render("plugin_config_add_field.html")
+      render_add_field(response)
     }
   );
 
@@ -533,10 +605,19 @@ exports.Initialise = (config, router, prototypeKit) => {
   router.post(
     IMPORTER_ROUTE_MAP.get("importerConfigurationField"),
     (request, response) => {
+      if (!request.body.field) {
+        render_add_field(response, "Missing value", "You must provide a name for the field using only alphanumeric characters or whitespace")
+        return
+      }
+
       if (request.body.action == "delete") {
         plugin_config.setFields(plugin_config.fields.filter((x) => x != request.body.field))
       } else {
-        plugin_config.setFields([...plugin_config.fields, request.body.field])
+        // We don't want to add a field if it already exists (by name), and so we will
+        // just return if it is already included.
+        if (!plugin_config.fields.find((x) => x.toUpperCase() == request.body.field.toUpperCase())) {
+          plugin_config.setFields([...plugin_config.fields, request.body.field])
+        }
       }
 
       response.redirect(IMPORTER_ROUTE_MAP.get("importerConfiguration"));

--- a/lib/importer/src/index.js
+++ b/lib/importer/src/index.js
@@ -20,7 +20,8 @@ const IMPORTER_ROUTE_MAP = new Map([
   ["importerReviewDataPath", "/importer/review"],
   ["importerSelectHeaderPath", "/importer/header_selection"],
   ["importerSelectFooterPath", "/importer/footer_selection"],
-  ["importerConfiguration", "/importer/config"]
+  ["importerConfiguration", "/importer/config"],
+  ["importerConfigurationField", "/importer/config/field"]
 ]);
 
 exports.Initialise = (config, router, prototypeKit) => {
@@ -510,22 +511,37 @@ exports.Initialise = (config, router, prototypeKit) => {
   // Configuration management routes.
   //--------------------------------------------------------------------
 
+  // Render the config page
   router.get(
     IMPORTER_ROUTE_MAP.get("importerConfiguration"),
     (request, response) => {
       response.status(200)
-      response.render("plugin_config.html")
+      response.render("plugin_config.html", { "config": plugin_config })
     }
   );
 
-  router.post(
-    IMPORTER_ROUTE_MAP.get("importerConfiguration"),
+  // Render the add a field page
+  router.get(
+    IMPORTER_ROUTE_MAP.get("importerConfigurationField"),
     (request, response) => {
-      response.status(401)
+      response.status(200)
+      response.render("plugin_config_add_field.html")
     }
   );
 
+  // Add or delete a field based on the action supplied by the form
+  router.post(
+    IMPORTER_ROUTE_MAP.get("importerConfigurationField"),
+    (request, response) => {
+      if (request.body.action == "delete") {
+        plugin_config.setFields(plugin_config.fields.filter((x) => x != request.body.field))
+      } else {
+        plugin_config.setFields([...plugin_config.fields, request.body.field])
+      }
 
+      response.redirect(IMPORTER_ROUTE_MAP.get("importerConfiguration"));
+    }
+  );
 
   //--------------------------------------------------------------------
   // Review the processing for the current session before continuing.

--- a/lib/importer/src/index.js
+++ b/lib/importer/src/index.js
@@ -1,5 +1,6 @@
 const multer = require("multer");
 const conf = require("./config.js");
+const path = require("node:path");
 const session_lib = require("./session.js");
 const sheets_lib = require("./sheets.js");
 
@@ -19,10 +20,36 @@ const IMPORTER_ROUTE_MAP = new Map([
   ["importerReviewDataPath", "/importer/review"],
   ["importerSelectHeaderPath", "/importer/header_selection"],
   ["importerSelectFooterPath", "/importer/footer_selection"],
+  ["importerConfiguration", "/importer/config"]
 ]);
 
 exports.Initialise = (config, router, prototypeKit) => {
   const plugin_config = new conf.PluginConfig(config);
+
+  //--------------------------------------------------------------------
+  // To be able to add a local views folder, we need to update the
+  // nunjucks environment's default loader to include the local folder.
+  // We can only do that with a reference to the underlying app, so
+  // this middleware is used to check if the local directory is already
+  // included, and add it if not.  This is enough to ensure that the
+  // first request to `importerConfiguration` will be able to render
+  // the template with the standard styling.
+  //--------------------------------------------------------------------
+  router.use("/importer", function (request, response, next) {
+    ensureLocalViews(request.app);
+    next()
+  })
+
+  const ensureLocalViews = (app) => {
+    const currentLoader = app.settings.nunjucksEnv.loaders[0]
+    const localViewsDir = path.resolve(__dirname, '../views')
+
+    // Only add the local views directory if it is not already included
+    if (!currentLoader.appViews.find((element) => element == localViewsDir)) {
+      currentLoader.init([...currentLoader.appViews, localViewsDir])
+    }
+  }
+
 
   //--------------------------------------------------------------------
   // Removes any previous importer error from the session. When we set
@@ -306,10 +333,12 @@ exports.Initialise = (config, router, prototypeKit) => {
   router.all(
     IMPORTER_ROUTE_MAP.get("importerStartPath"),
     (request, response) => {
+
       cleanRequest(request);
       redirectOnwards(request, response);
     },
   );
+
 
   //--------------------------------------------------------------------
   // Uploads a file and initiates a new upload session, storing the
@@ -476,6 +505,27 @@ exports.Initialise = (config, router, prototypeKit) => {
       redirectOnwards(request, response);
     },
   );
+
+  //--------------------------------------------------------------------
+  // Configuration management routes.
+  //--------------------------------------------------------------------
+
+  router.get(
+    IMPORTER_ROUTE_MAP.get("importerConfiguration"),
+    (request, response) => {
+      response.status(200)
+      response.render("plugin_config.html")
+    }
+  );
+
+  router.post(
+    IMPORTER_ROUTE_MAP.get("importerConfiguration"),
+    (request, response) => {
+      response.status(401)
+    }
+  );
+
+
 
   //--------------------------------------------------------------------
   // Review the processing for the current session before continuing.

--- a/lib/importer/src/index.js
+++ b/lib/importer/src/index.js
@@ -46,6 +46,13 @@ exports.Initialise = (config, router, prototypeKit) => {
     next()
   })
 
+  // Add globals to the nunjucks namespace where we do not have access to the
+  // nunjucks environment
+  router.use("/", function (request, response, next) {
+    request.app.settings.nunjucksEnv.addGlobal("isDevelopmentMode", developmentMode)
+    next()
+  })
+
   const ensureLocalViews = (app) => {
     const currentLoader = app.settings.nunjucksEnv.loaders[0]
     const localViewsDir = path.resolve(__dirname, '../views')
@@ -67,6 +74,7 @@ exports.Initialise = (config, router, prototypeKit) => {
     delete request.session.data['reference_number'];
     delete request.session.data[IMPORTER_ERROR_KEY];
   };
+
 
   //--------------------------------------------------------------------
   // Make the route functions available in the templates. These functions

--- a/lib/importer/src/index.js
+++ b/lib/importer/src/index.js
@@ -27,6 +27,9 @@ const IMPORTER_ROUTE_MAP = new Map([
 ]);
 
 exports.Initialise = (config, router, prototypeKit) => {
+
+  const developmentMode = config.isDevelopment;
+
   const plugin_config = new conf.PluginConfig(config);
 
   //--------------------------------------------------------------------
@@ -513,74 +516,77 @@ exports.Initialise = (config, router, prototypeKit) => {
   // Configuration management routes.
   //--------------------------------------------------------------------
 
-  const TEMP_DIRECTORY_LABEL = "[Temporary directory]"
-
-  // Render the config page
-  router.get(
-    IMPORTER_ROUTE_MAP.get("importerConfiguration"),
-    (request, response) => {
-      const pc = {
-        config: {
-          fields: plugin_config.fields,
-          uploadPath: plugin_config.uploadPathDefault ? TEMP_DIRECTORY_LABEL : plugin_config.uploadPath
+  if (developmentMode) {
+    // Render the config page
+    router.get(
+      IMPORTER_ROUTE_MAP.get("importerConfiguration"),
+      (request, response) => {
+        const pc = {
+          config: {
+            fields: plugin_config.fields
+          }
         }
-      }
 
-      // Copy flash message to template object and then remove from memory
-      if (request.session.data['internal-message']) {
-        pc.message = request.session.data['internal-message']
-        request.session.data['internal-message'] = null
-      }
-
-      // This is a bit of a hacky way to render the error in the GET counterpart to a
-      // previous POST request at this URL.
-      if (request.session.data['internal-error']) {
-        pc.error_summary = request.session.data['internal-error'].summary
-        pc.error = request.session.data['internal-error'].error
-        pc.config.uploadPath = request.session.data['internal-error'].parameter
-        request.session.data['internal-error'] = null
-      }
-
-      response.status(200)
-      response.render("plugin_config.html", pc)
-    }
-  );
-
-
-  router.post(
-    IMPORTER_ROUTE_MAP.get("importerConfiguration"),
-    (request, response) => {
-      request.session.data['internal-message'] = "Configuration changes have been saved, and the application will restart shortly"
-
-      setTimeout(function () {
-        plugin_config.persistConfig()
-      }, 5000)
-
-      response.redirect(IMPORTER_ROUTE_MAP.get("importerConfiguration"))
-    }
-  );
-
-  router.post(
-    IMPORTER_ROUTE_MAP.get("importerConfigurationPath"),
-    (request, response) => {
-      let newPath = request.body.uploadPath
-
-      if (newPath && !fs.existsSync(newPath)) {
-        request.session.data['internal-error'] = {
-          summary: "Directory does not exists",
-          error: "The specified path does not exist on the computer where the prototype kit is executing. Please choose another path or set to empty for the default value. The plugin will not operate until this error is corrected",
-          parameter: newPath
+        // Copy flash message to template object and then remove from memory
+        if (request.session.data['internal-message']) {
+          pc.message = request.session.data['internal-message']
+          request.session.data['internal-message'] = null
         }
+
+        // This is a bit of a hacky way to render the error in the GET counterpart to a
+        // previous POST request at this URL.
+        if (request.session.data['internal-error']) {
+          pc.error_summary = request.session.data['internal-error'].summary
+          pc.error = request.session.data['internal-error'].error
+          request.session.data['internal-error'] = null
+        }
+
+        response.status(200)
+        response.render("plugin_config.html", pc)
+      }
+    );
+
+
+    router.post(
+      IMPORTER_ROUTE_MAP.get("importerConfiguration"),
+      (request, response) => {
+        request.session.data['internal-message'] = "Configuration changes have been saved, and the application will restart shortly"
+
+        setTimeout(function () {
+          plugin_config.persistConfig()
+        }, 5000)
+
         response.redirect(IMPORTER_ROUTE_MAP.get("importerConfiguration"))
-        return
       }
+    );
 
-      plugin_config.setUploadPath(newPath)
+    router.post(
+      IMPORTER_ROUTE_MAP.get("importerConfigurationPath"),
+      (request, response) => {
+        let newPath = request.body.uploadPath
 
-      response.redirect(IMPORTER_ROUTE_MAP.get("importerConfiguration"))
-    }
-  )
+        if (newPath && !fs.existsSync(newPath)) {
+          request.session.data['internal-error'] = {
+            summary: "Directory does not exist",
+            error: "The specified path does not exist on the computer where the prototype kit is executing. Please choose another path or set to empty for the default value. The plugin will not operate until this error is corrected",
+            parameter: newPath
+          }
+          response.redirect(IMPORTER_ROUTE_MAP.get("importerConfiguration"))
+          return
+        }
 
+        response.redirect(IMPORTER_ROUTE_MAP.get("importerConfiguration"))
+      }
+    )
+  } else {
+    // Disable all handling for configuration pages when not in development mode
+    router.all(
+      IMPORTER_ROUTE_MAP.get("importerConfiguration"),
+      (request, response) => {
+        response.status(200)
+        response.render("plugin_config_disabled.html")
+      })
+  }
 
 
   function render_add_field(res, summary, error) {

--- a/lib/importer/views/layouts/main.html
+++ b/lib/importer/views/layouts/main.html
@@ -1,0 +1,1 @@
+{% extends "govuk-prototype-kit/layouts/govuk-branded.njk" %}

--- a/lib/importer/views/plugin_config.html
+++ b/lib/importer/views/plugin_config.html
@@ -3,12 +3,55 @@
 {% set pageName="Plugin Configuration" %}
 
 {% block content %}
-
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-xl">
         Plugin Configuration
     </h1>
+
+    <div class="govuk-grid-column-two-thirds">
+      <h2 class="govuk-heading-l">Data fields to map imported data to</h2>
+
+      <ul class="govuk-task-list">
+        {% for field in config.fields %}
+        <form action="config/field" method="post">
+          <input type="hidden" name="action" value="delete"/>
+          <input type="hidden" name="field" value="{{field}}"/>
+          <li class="govuk-task-list__item govuk-task-list__item--with-link">
+            <div class="govuk-task-list__name-and-hint">
+                {{field}}
+            </div>
+            <div class="govuk-task-list__status" id="company-details-1-status">
+              <button type="submit" class="govuk-button govuk-button--warning govuk-!-static-margin-bottom-0" data-module="govuk-button">Delete</button>
+            </div>
+          </li>
+        </form>
+        {% endfor %}
+      </ul>
+
+      <p>
+        <a class="govuk-link" href="config/field">Add another</a>
+      </p>
+
+    </div>
+
+    <div class="govuk-grid-column-two-thirds">
+
+      <h2 class="govuk-heading-l">Storing uploaded spreadsheets</h2>
+
+      {% if config.uploadPathDefault %}
+        {% set current_upload = "[Temporary directory]" %}
+      {% else %}
+        {% set current_upload = config.uploadPath %}
+      {% endif %}
+
+        <label class="govuk-label" for="event-name">
+          Upload directory
+        </label>
+      </h1>
+
+        <input class="govuk-input" id="event-name" name="eventName" type="text" value="{{current_upload}}">
+    </div>
 
   </div>
 </div>

--- a/lib/importer/views/plugin_config.html
+++ b/lib/importer/views/plugin_config.html
@@ -9,9 +9,57 @@
         Plugin Configuration
     </h1>
 
-    <div class="govuk-grid-column-two-thirds">
-      <h2 class="govuk-heading-l">Data fields to map imported data to</h2>
 
+    {% if message %}
+    <div class="govuk-panel govuk-panel--confirmation">
+      <h1 class="govuk-panel__title">
+        Configuration saved
+      </h1>
+      <div class="govuk-panel__body">
+        {{ message }}
+      </div>
+    </div>
+
+  {% endif %}
+
+
+
+    {% if error %}
+    <div class="govuk-error-summary" data-module="govuk-error-summary">
+      <div role="alert">
+        <h2 class="govuk-error-form_err">
+          There was a problem with your submission
+        </h2>
+        <div class="govuk-error-summary__body">
+          <ul class="govuk-list govuk-error-summary__list">
+            <li>
+              <a href="#uploadPath">{{ error_summary }}</a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+    {% endif %}
+
+
+    <div class="govuk-grid-column-two-thirds"></div>
+      <p class="govuk-body-l">
+        This page allows you to configure the plugin by specifying what the imported data
+        should look like after processing, and where uploaded spreadsheets should be stored.
+      </p>
+    </div>
+
+    <div class="govuk-grid-column-full">
+      <h2 class="govuk-heading-l">Data map</h2>
+
+      <p class="govuk-body">
+        When importing a spreadsheet, each row of the identified table will be mapped to a new record
+        which you can specify here. Once you have selected the table in the uploaded file you will be
+        asked to map each column to one of the fields defined here.
+      </p>
+    </div>
+
+    <div class="govuk-grid-column-two-thirds">
       <ul class="govuk-task-list">
         {% for field in config.fields %}
         <form action="config/field" method="post">
@@ -29,28 +77,67 @@
         {% endfor %}
       </ul>
 
-      <p>
-        <a class="govuk-link" href="config/field">Add another</a>
-      </p>
+
+      <div class="govuk-button-group">
+        <a class="govuk-button govuk-button--secondary" href="config/field">Add another</a>
+      </div>
 
     </div>
 
-    <div class="govuk-grid-column-two-thirds">
 
+    <div class="govuk-grid-column-full govuk-!-padding-top-6" >
       <h2 class="govuk-heading-l">Storing uploaded spreadsheets</h2>
 
-      {% if config.uploadPathDefault %}
-        {% set current_upload = "[Temporary directory]" %}
-      {% else %}
-        {% set current_upload = config.uploadPath %}
-      {% endif %}
+      <p class="govuk-body">
+        By default, uploaded spreadsheets are stored in an auto-determined temporary folder.
+        This means that you only need to modify this setting if you have an explicit need to
+        store the uploaded data elsewhere. In almost all cases you can ignore this section.
+      </p>
 
-        <label class="govuk-label" for="event-name">
-          Upload directory
-        </label>
-      </h1>
+      <form action="config/path" method="post">
+        <div class="govuk-form-group {% if error %}govuk-form-group--error{% endif %}">
+          <label class="govuk-label" for="upload-path">
+            Upload directory
+          </label>
 
-        <input class="govuk-input" id="event-name" name="eventName" type="text" value="{{current_upload}}">
+          {% if error %}
+          <p id="path_err" class="govuk-error-message">
+            <span class="govuk-visually-hidden">Error:</span> {{ error }}
+          </p>
+          {% endif %}
+
+
+          <input class="govuk-input" id="uploadPath" name="uploadPath" type="text" value="{{ config.uploadPath }}">
+        </div>
+        <div class="govuk-button-group">
+          <button type="submit" class="govuk-button govuk-button--secondary" data-module="govuk-button">Update path</button>
+        </div>
+      </form>
+    </div>
+
+
+    <div class="govuk-grid-column-full govuk-!-padding-top-6" >
+      <h2 class="govuk-heading-l">Save changes</h2>
+
+      <p class="govuk-body">
+        Saving the changes to configuration will ensure that the next time you run the
+        prototype kit it will use this configuration. Once saved the application will
+        restart with the new configuration in place and any use of the prototype kit will
+        use the new settings.
+      </p>
+
+      <form action="config" method="post">
+        <div class="govuk-form-group {% if error %}govuk-form-group--error{% endif %}">
+          {% if error %}
+          <p id="path_err" class="govuk-error-message">
+            <span class="govuk-visually-hidden">Error:</span> {{ error }}
+          </p>
+          {% endif %}
+        </div>
+        <div class="govuk-button-group">
+          <button type="submit" class="govuk-button" data-module="govuk-button">Save configuration</button>
+        </div>
+      </form>
     </div>
 
   </div>

--- a/lib/importer/views/plugin_config.html
+++ b/lib/importer/views/plugin_config.html
@@ -50,7 +50,7 @@
     </div>
 
     <div class="govuk-grid-column-full">
-      <h2 class="govuk-heading-l">Data map</h2>
+      <h2 class="govuk-heading-l">Column settings</h2>
 
       <p class="govuk-body">
         When importing a spreadsheet, each row of the identified table will be mapped to a new record
@@ -83,38 +83,6 @@
       </div>
 
     </div>
-
-
-    <div class="govuk-grid-column-full govuk-!-padding-top-6" >
-      <h2 class="govuk-heading-l">Storing uploaded spreadsheets</h2>
-
-      <p class="govuk-body">
-        By default, uploaded spreadsheets are stored in an auto-determined temporary folder.
-        This means that you only need to modify this setting if you have an explicit need to
-        store the uploaded data elsewhere. In almost all cases you can ignore this section.
-      </p>
-
-      <form action="config/path" method="post">
-        <div class="govuk-form-group {% if error %}govuk-form-group--error{% endif %}">
-          <label class="govuk-label" for="upload-path">
-            Upload directory
-          </label>
-
-          {% if error %}
-          <p id="path_err" class="govuk-error-message">
-            <span class="govuk-visually-hidden">Error:</span> {{ error }}
-          </p>
-          {% endif %}
-
-
-          <input class="govuk-input" id="uploadPath" name="uploadPath" type="text" value="{{ config.uploadPath }}">
-        </div>
-        <div class="govuk-button-group">
-          <button type="submit" class="govuk-button govuk-button--secondary" data-module="govuk-button">Update path</button>
-        </div>
-      </form>
-    </div>
-
 
     <div class="govuk-grid-column-full govuk-!-padding-top-6" >
       <h2 class="govuk-heading-l">Save changes</h2>

--- a/lib/importer/views/plugin_config.html
+++ b/lib/importer/views/plugin_config.html
@@ -1,0 +1,16 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="Plugin Configuration" %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+        Plugin Configuration
+    </h1>
+
+  </div>
+</div>
+
+{% endblock %}

--- a/lib/importer/views/plugin_config_add_field.html
+++ b/lib/importer/views/plugin_config_add_field.html
@@ -1,0 +1,30 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="Plugin Configuration - Add field" %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-xl">
+        Add a new field
+    </h1>
+   </div>
+
+   <form action="/importer/config/field" method="post">
+      <div class="govuk-form-group">
+        <label class="govuk-label" for="field-name">
+          Name for the field
+        </label>
+        <input class="govuk-input" id="field-name" name="field" type="text">
+      </div>
+
+      <div class="govuk-button-group">
+        <input type="submit" class="govuk-button" value="Add"/>
+        <a class="govuk-link" href="/importer/config">Cancel</a>
+      </div>
+   </form>
+</div>
+
+
+{% endblock %}

--- a/lib/importer/views/plugin_config_add_field.html
+++ b/lib/importer/views/plugin_config_add_field.html
@@ -5,17 +5,41 @@
 {% block content %}
 
 <div class="govuk-grid-row">
+
+  {% if error %}
+  <div class="govuk-error-summary" data-module="govuk-error-summary">
+    <div role="alert">
+      <h2 class="govuk-error-form_err">
+        There was a problem with your submission
+      </h2>
+      <div class="govuk-error-summary__body">
+        <ul class="govuk-list govuk-error-summary__list">
+          <li>
+            <a href="#form_err">{{ error_summary }}</a>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+  {% endif %}
+
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-xl">
         Add a new field
     </h1>
-   </div>
 
    <form action="/importer/config/field" method="post">
-      <div class="govuk-form-group">
+      <div class="govuk-form-group {% if error %}govuk-form-group--error{% endif %}">
         <label class="govuk-label" for="field-name">
           Name for the field
         </label>
+
+        {% if error %}
+        <p id="form_err" class="govuk-error-message">
+          <span class="govuk-visually-hidden">Error:</span> {{ error }}
+        </p>
+        {% endif %}
+
         <input class="govuk-input" id="field-name" name="field" type="text">
       </div>
 
@@ -24,6 +48,7 @@
         <a class="govuk-link" href="/importer/config">Cancel</a>
       </div>
    </form>
+  </div>
 </div>
 
 

--- a/lib/importer/views/plugin_config_add_field.html
+++ b/lib/importer/views/plugin_config_add_field.html
@@ -28,6 +28,17 @@
         Add a new field
     </h1>
 
+    <p class="govuk-body-l">
+      Each added field will be shown during the import to allow the user to
+      assign a specific column to it.
+    </p>
+
+    <p class="govuk-body">
+      When picking a name for the field you should choose something descriptive that your users
+      will understand when assigning it to a column. You should avoid punctuation although you may
+      use spaces and numbers in the name.
+    </p>
+
    <form action="/importer/config/field" method="post">
       <div class="govuk-form-group {% if error %}govuk-form-group--error{% endif %}">
         <label class="govuk-label" for="field-name">

--- a/lib/importer/views/plugin_config_disabled.html
+++ b/lib/importer/views/plugin_config_disabled.html
@@ -1,0 +1,23 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="Plugin Configuration" %}
+
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+
+    <div class="govuk-panel govuk-panel--warning">
+      <h1 class="govuk-panel__title">
+        Configuration disabled
+      </h1>
+      <div class="govuk-panel__body">
+        The configuration page is only available when building the prototype
+        on your local system. Updating the configuration in production is not
+        enabled.
+      </div>
+    </div>
+
+  </div>
+</div>
+
+{% endblock %}

--- a/prototypes/basic/app/assets/sass/application.scss
+++ b/prototypes/basic/app/assets/sass/application.scss
@@ -39,3 +39,8 @@ pre {
     border-top: 1px solid #b1b4b6;
     padding-top: 1em;
 }
+
+.govuk-panel--warning {
+    color: #ffffff;
+    background: #f42d52;
+}

--- a/prototypes/basic/app/config.json
+++ b/prototypes/basic/app/config.json
@@ -9,5 +9,6 @@
     "Salary",
     "Contribution percentage",
     "Payment date"
-  ]
+  ],
+  "uploadPath": ""
 }

--- a/prototypes/basic/app/views/layouts/footer.html
+++ b/prototypes/basic/app/views/layouts/footer.html
@@ -2,6 +2,23 @@
   <div class="govuk-width-container">
       <div class="govuk-footer__meta">
           <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
+
+            {% if isDevelopmentMode %}
+            <h2 class="govuk-visually-hidden">Support links</h2>
+            <ul class="govuk-footer__inline-list">
+              <li class="govuk-footer__inline-list-item">
+                <a class="govuk-footer__link" href="/manage-prototype">
+                    Manage prototype
+                </a>
+              </li>
+              <li class="govuk-footer__inline-list-item">
+                <a class="govuk-footer__link" href="/manage-prototype/clear-data">
+                    Clear data
+                </a>
+              </li>
+            </ul>
+            {% endif %}
+
               <svg aria-hidden="true" focusable="false" class="govuk-footer__licence-logo"
                   xmlns="http://www.w3.org/2000/svg" viewBox="0 0 483.2 195.7" height="17" width="41">
                   <path fill="currentColor"


### PR DESCRIPTION
These changes allow the plugin to manage its own configuration with a set of pages. These pages allow the user to add/delete fields to be mapped along with the settings of the upload page.  

We may decide to hide the upload path as an advanced option as most users will not need to change it, and those that do are likely able to do so in the app/config.json file.

The pages can be accessed via `http://127.0.0.1:3000/importer/config`

### Configuration Page
![config](https://github.com/user-attachments/assets/510912a5-1321-4a80-9fb7-5005a28f9b2e)


### Add a field 
![add-field](https://github.com/user-attachments/assets/974b5218-0c97-4af7-9f5d-9e7d48eef035)


### Add a field with error
![add-field-error](https://github.com/user-attachments/assets/ef1a16c2-9fbf-4b60-8c9c-82cb9eab93de)



These changes are quite isolated and so shouldn't break anything in the any in-use code.