### PR TITLE
Change the structure for mapping fields in config

### DIFF
--- a/lib/importer/assets/docs/start.html
+++ b/lib/importer/assets/docs/start.html
@@ -124,7 +124,7 @@
                 your machine. It can be installed directly into the GOV.UK
                 Prototype Kit.
               </p>
-              <div data-static-only>
+              <div>
                 <p>
                   Open up your preferred command line, which you previously used to create a GOV.UK Prototype, and type the following:
               </p>
@@ -135,13 +135,26 @@
                 configure the plugin, which can be done by editing the
                 <code>app/config.json</code> to look something like the following, replacing
                 the fields with the headings for the data you are interested in.
+                Alternatively you can manage your configuration file via the <a href="/importer/config">configuration tool</a>
               </p>
               <pre>{
     "serviceName": "Your service name",
     "fields": [
-        "Code",
-        "Name",
-        "Speciality"
+        {
+            "name": "Code",
+            "type": "number",
+            "required": true
+        },
+        {
+            "name": "Name",
+            "type": "string",
+            "required": true
+        },
+        {
+            "name": "Speciality",
+            "type": "string",
+            "required": false
+        },
     ]
 }</pre>
             </div>

--- a/lib/importer/assets/docs/start.html
+++ b/lib/importer/assets/docs/start.html
@@ -147,12 +147,12 @@
         },
         {
             "name": "Name",
-            "type": "string",
+            "type": "text",
             "required": true
         },
         {
             "name": "Speciality",
-            "type": "string",
+            "type": "text",
             "required": false
         },
     ]

--- a/lib/importer/nunjucks/importer/macros/field_mapper.njk
+++ b/lib/importer/nunjucks/importer/macros/field_mapper.njk
@@ -46,7 +46,7 @@
          <select class="govuk-select" style="float: right;" name="{{h.index}}">
                 <option name=""></option>
                 {% for field in fields %}
-                <option value="{{field}}">{{field}}</option>
+                <option value="{{field.name}}">{{field.name}}</option>
                 {% endfor %}
             </select>
       </td>

--- a/lib/importer/src/attribute-types.js
+++ b/lib/importer/src/attribute-types.js
@@ -38,9 +38,9 @@ function failedMapping(warnings, errors) {
 // undefined values and maps then to "undefined", and converts any validation errors to warnings
 exports.optionalType = (baseType) => {
   return (inputValue) => {
-    if(inputValue !== undefined && inputValue != "") {
+    if (inputValue !== undefined && inputValue != "") {
       const result = baseType(inputValue);
-      if(result.valid) {
+      if (result.valid) {
         return result;
       } else {
         // Convert any errors into warnings, as this is an optional field
@@ -56,7 +56,7 @@ exports.optionalType = (baseType) => {
 // Create a required version of an existing type, that reports an undefined or empty-string input value as an error
 exports.requiredType = (baseType) => {
   return (inputValue) => {
-    if(inputValue !== undefined && inputValue != "") {
+    if (inputValue !== undefined && inputValue != "") {
       return baseType(inputValue);
     }
     else {
@@ -73,9 +73,20 @@ exports.basicStringType = (inputValue) => {
 // The default numeric type
 exports.basicNumberType = (inputValue) => {
   const result = parseFloat(inputValue);
-  if(isNaN(result)) {
+  if (isNaN(result)) {
     return failedMapping([], ["This is not a valid number"]);
   } else {
     return successfulMapping(result);
   }
 };
+
+exports.typeFromName = (name) => {
+  if (!name) return null
+
+  switch (name.toLowerCase()) {
+    case "number":
+      return exports.basicNumberType
+    default:
+      return exports.basicStringType
+  }
+}

--- a/lib/importer/src/config.js
+++ b/lib/importer/src/config.js
@@ -10,6 +10,7 @@
 // we isolate the fields specific to the plugin here, and store the location of
 // the config.json so that we can write write to it at runtime.
 //
+const attrTypes = require("./attribute-types")
 const fs = require("fs");
 const fse = require("fs-extra");
 const path = require("node:path");
@@ -17,11 +18,37 @@ const os = require("node:os");
 
 const TEMP_DIRECTORY_LABEL = "[Temporary directory]"
 
+exports.MappingField = class {
+  constructor(f = {}) {
+    this.name = f.name
+    this.required = f.required
+    this.type = f.type
+  }
+
+  mapperForField = () => {
+    const fieldType = attrTypes.typeFromName(this.type)
+    if (this.required) {
+      return attrTypes.requiredType(fieldType)
+    }
+
+    return attrTypes.optionalType(fieldType)
+  }
+
+}
+
 exports.PluginConfig = class {
   constructor(config = {}) {
     this.fields = config.fields || [];
     this.uploadPath = config.uploadPath;
     this.uploadPathDefault = false;
+
+    // If the config fields are in the old format (just names) then move them to
+    // the new structure with default values of string for the type, and not required.
+    if (this.fields.find(Boolean)) {
+      if (typeof this.fields[0] === 'string' || this.fields[0] instanceof String) {
+        this.fields = this.fields.map((x) => new exports.MappingField({ name: x, type: "string", required: false }))
+      }
+    }
 
     if (this.uploadPath == null || this.uploadPath == "") {
       this.uploadPath = path.join(os.tmpdir(), "reg-dyn-importer");

--- a/lib/importer/src/config.js
+++ b/lib/importer/src/config.js
@@ -43,10 +43,10 @@ exports.PluginConfig = class {
     this.uploadPathDefault = false;
 
     // If the config fields are in the old format (just names) then move them to
-    // the new structure with default values of string for the type, and not required.
+    // the new structure with default values of text for the type, and not required.
     if (this.fields.find(Boolean)) {
       if (typeof this.fields[0] === 'string' || this.fields[0] instanceof String) {
-        this.fields = this.fields.map((x) => new exports.MappingField({ name: x, type: "string", required: false }))
+        this.fields = this.fields.map((x) => new exports.MappingField({ name: x, type: "text", required: false }))
       }
     }
 

--- a/lib/importer/src/config.test.js
+++ b/lib/importer/src/config.test.js
@@ -4,7 +4,7 @@ const fs = require('node:fs');
 const mock_files = require('mock-fs');
 
 
-function fieldHelper(name, typ = "string", required = true) {
+function fieldHelper(name, typ = "text", required = true) {
     return {
         name: name, type: typ, required: required
     }
@@ -79,7 +79,7 @@ describe("Configuration tests", () => {
                 expect(original.fields.map((x) => x.name)).toStrictEqual(["A", "B", "C"])
                 expect(updated.fields.map((x) => x.name)).toStrictEqual(["A", "B"])
                 expect(c.fields.map((x) => x.name)).toStrictEqual(["A", "B"])
-                expect(c.fields.map((x) => x.type)).toStrictEqual(["string", "string"])
+                expect(c.fields.map((x) => x.type)).toStrictEqual(["text", "text"])
                 expect(c.fields.map((x) => x.required)).toStrictEqual([true, true])
             }
         );
@@ -103,7 +103,7 @@ describe("Configuration tests", () => {
                 expect(original.fields.map((x) => x.name)).toStrictEqual(["A", "B", "C"])
                 expect(updated.fields.map((x) => x.name)).toStrictEqual(["A", "B"])
                 expect(c.fields.map((x) => x.name)).toStrictEqual(["A", "B"])
-                expect(c.fields.map((x) => x.type)).toStrictEqual(["string", "number"])
+                expect(c.fields.map((x) => x.type)).toStrictEqual(["text", "number"])
                 expect(c.fields.map((x) => x.required)).toStrictEqual([true, true])
             }
         );

--- a/lib/importer/src/config.test.js
+++ b/lib/importer/src/config.test.js
@@ -4,6 +4,12 @@ const fs = require('node:fs');
 const mock_files = require('mock-fs');
 
 
+function fieldHelper(name, typ = "string", required = true) {
+    return {
+        name: name, type: typ, required: required
+    }
+}
+
 describe("Configuration tests", () => {
 
     test('initial empty config', () => {
@@ -15,13 +21,13 @@ describe("Configuration tests", () => {
             "./empty",
             new cfg.PluginConfig(),
             (c) => {
-                c.setFields(["A"])
+                c.setFields([fieldHelper("A")])
                 c.persistConfig()
             },
             (original, updated, c) => {
                 expect(original.fields).toBeUndefined()
-                expect(updated.fields).toStrictEqual(["A"])
-                expect(c.fields).toStrictEqual(["A"])
+                expect(updated.fields[0].name).toStrictEqual("A")
+                expect(c.fields[0].name).toStrictEqual("A")
 
                 // We expect a non-null value by default, but can't construct something
                 // to compare against as the tmp directory given may be different on
@@ -37,20 +43,68 @@ describe("Configuration tests", () => {
 
     test('existing fields', () => {
         mock_files({
-            './fields/app/config.json': '{"fields": ["A", "B", "C"]}',
+            './fields/app/config.json': '{"fields": [{"name":"A"}, {"name": "B"}, {"name": "C"}]}',
         })
 
         withCurrent(
             "./fields",
             new cfg.PluginConfig(),
             (c) => {
-                c.setFields(["A", "B"])
+                c.setFields([fieldHelper("A"), fieldHelper("B")])
                 c.persistConfig()
             },
             (original, updated, c) => {
-                expect(original.fields).toStrictEqual(["A", "B", "C"])
-                expect(updated.fields).toStrictEqual(["A", "B"])
-                expect(c.fields).toStrictEqual(["A", "B"])
+                expect(original.fields.map((x) => x.name)).toStrictEqual(["A", "B", "C"])
+                expect(updated.fields.map((x) => x.name)).toStrictEqual(["A", "B"])
+                expect(c.fields.map((x) => x.name)).toStrictEqual(["A", "B"])
+            }
+        );
+
+        mock_files.restore();
+    });
+
+    test('migration from only field name to inc type and required', () => {
+        mock_files({
+            './fields/app/config.json': '{"fields": [{"name":"A"}, {"name": "B"}, {"name": "C"}]}',
+        })
+
+        withCurrent(
+            "./fields",
+            new cfg.PluginConfig(),
+            (c) => {
+                c.setFields([fieldHelper("A"), fieldHelper("B")])
+                c.persistConfig()
+            },
+            (original, updated, c) => {
+                expect(original.fields.map((x) => x.name)).toStrictEqual(["A", "B", "C"])
+                expect(updated.fields.map((x) => x.name)).toStrictEqual(["A", "B"])
+                expect(c.fields.map((x) => x.name)).toStrictEqual(["A", "B"])
+                expect(c.fields.map((x) => x.type)).toStrictEqual(["string", "string"])
+                expect(c.fields.map((x) => x.required)).toStrictEqual([true, true])
+            }
+        );
+
+        mock_files.restore();
+    });
+
+    test('supports new field structure', () => {
+        mock_files({
+            './fields/app/config.json': '{"fields": [{"name":"A", "type": "number"}, {"name": "B"}, {"name": "C"}]}',
+        })
+
+        withCurrent(
+            "./fields",
+            new cfg.PluginConfig(),
+            (c) => {
+                c.setFields([fieldHelper("A"), fieldHelper("B", "number")])
+                c.persistConfig()
+            },
+            (original, updated, c) => {
+                expect(original.fields.map((x) => x.name)).toStrictEqual(["A", "B", "C"])
+                expect(updated.fields.map((x) => x.name)).toStrictEqual(["A", "B"])
+                expect(c.fields.map((x) => x.name)).toStrictEqual(["A", "B"])
+                expect(c.fields.map((x) => x.type)).toStrictEqual(["string", "number"])
+                expect(c.fields.map((x) => x.required)).toStrictEqual([true, true])
             }
         );
 
@@ -100,9 +154,7 @@ describe("Configuration tests", () => {
 function withCurrent(rootFolder, pluginConfig, cbFunction, assertionsFunc) {
     assert(typeof (cbFunction) === 'function')
     assert(typeof (assertionsFunc) === 'function')
-
     process.env.KIT_PROJECT_DIR = rootFolder
-
     const original = JSON.parse(fs.readFileSync(pluginConfig.configPath, 'utf8'));
     cbFunction(pluginConfig)
     const updated = JSON.parse(fs.readFileSync(pluginConfig.configPath, 'utf8'));

--- a/lib/importer/src/index.js
+++ b/lib/importer/src/index.js
@@ -562,7 +562,7 @@ exports.Initialise = (config, router, prototypeKit) => {
 
         setTimeout(function () {
           plugin_config.persistConfig()
-        }, 5000)
+        }, 2500)
 
         response.redirect(IMPORTER_ROUTE_MAP.get("importerConfiguration"))
       }

--- a/lib/importer/src/index.js
+++ b/lib/importer/src/index.js
@@ -609,8 +609,8 @@ exports.Initialise = (config, router, prototypeKit) => {
         } else {
           // We don't want to add a field if it already exists (by name), and so we will
           // just return if it is already included.
-          if (!plugin_config.fields.find((x) => x.toUpperCase() == request.body.field.toUpperCase())) {
-            plugin_config.setFields([...plugin_config.fields, request.body.field])
+          if (!plugin_config.fields.find((x) => x.name.toUpperCase() == request.body.field.toUpperCase())) {
+            plugin_config.setFields([...plugin_config.fields, { name: request.body.field, type: "string", required: false }])
           }
         }
 

--- a/lib/importer/src/index.js
+++ b/lib/importer/src/index.js
@@ -610,7 +610,7 @@ exports.Initialise = (config, router, prototypeKit) => {
           // We don't want to add a field if it already exists (by name), and so we will
           // just return if it is already included.
           if (!plugin_config.fields.find((x) => x.name.toUpperCase() == request.body.field.toUpperCase())) {
-            plugin_config.setFields([...plugin_config.fields, { name: request.body.field, type: "string", required: false }])
+            plugin_config.setFields([...plugin_config.fields, { name: request.body.field, type: "text", required: false }])
           }
         }
 

--- a/lib/importer/src/index.js
+++ b/lib/importer/src/index.js
@@ -605,12 +605,14 @@ exports.Initialise = (config, router, prototypeKit) => {
         }
 
         if (request.body.action == "delete") {
-          plugin_config.setFields(plugin_config.fields.filter((x) => x != request.body.field))
+          plugin_config.setFields(plugin_config.fields.filter((x) => x.name != request.body.field))
         } else {
           // We don't want to add a field if it already exists (by name), and so we will
           // just return if it is already included.
           if (!plugin_config.fields.find((x) => x.name.toUpperCase() == request.body.field.toUpperCase())) {
-            plugin_config.setFields([...plugin_config.fields, { name: request.body.field, type: "text", required: false }])
+            const t = request.body.type ?? "text"
+            const r = (/true/).test(request.body.required)
+            plugin_config.setFields([...plugin_config.fields, { name: request.body.field, type: t, required: r }])
           }
         }
 

--- a/lib/importer/src/index.js
+++ b/lib/importer/src/index.js
@@ -279,7 +279,7 @@ exports.Initialise = (config, router, prototypeKit) => {
       const mapResults = sheets_lib.MapData(session);
       const headers = session.fields;
 
-      const idx = headers.findIndex((x) => x == column)
+      const idx = headers.findIndex((x) => x.name == column)
       if (idx == -1) {
         return "No data found"
       }
@@ -301,7 +301,7 @@ exports.Initialise = (config, router, prototypeKit) => {
       const mapResults = sheets_lib.MapData(session);
       const headers = session.fields;
 
-      const idx = headers.findIndex((x) => x == column)
+      const idx = headers.findIndex((x) => x.name == column)
       if (idx == -1) {
         return "No data found"
       }

--- a/lib/importer/src/session.test.js
+++ b/lib/importer/src/session.test.js
@@ -5,7 +5,7 @@ describe("Session tests", () => {
     test('default session', () => {
         const response = session.CreateSession(
             {
-                fields: ['field'],
+                fields: [{ name: 'field', type: 'string', required: false }],
                 uploadPath: "../../fixtures",
             },
             {
@@ -20,6 +20,6 @@ describe("Session tests", () => {
         expect(response.id).not.toBe('');
 
         expect(response.session.filename).toEqual('../../fixtures/test.xlsx');
-        expect(response.session.fields).toEqual(['field']);
+        expect(response.session.fields).toEqual([{ name: "field", type: "string", required: false }]);
     });
 });

--- a/lib/importer/src/session.test.js
+++ b/lib/importer/src/session.test.js
@@ -5,7 +5,7 @@ describe("Session tests", () => {
     test('default session', () => {
         const response = session.CreateSession(
             {
-                fields: [{ name: 'field', type: 'string', required: false }],
+                fields: [{ name: 'field', type: 'text', required: false }],
                 uploadPath: "../../fixtures",
             },
             {
@@ -20,6 +20,6 @@ describe("Session tests", () => {
         expect(response.id).not.toBe('');
 
         expect(response.session.filename).toEqual('../../fixtures/test.xlsx');
-        expect(response.session.fields).toEqual([{ name: "field", type: "string", required: false }]);
+        expect(response.session.fields).toEqual([{ name: "field", type: "text", required: false }]);
     });
 });

--- a/lib/importer/src/sheets.js
+++ b/lib/importer/src/sheets.js
@@ -257,9 +257,10 @@ exports.MapData = (session, previewLimit = DEFAULT_PREVIEW_LIMIT) => {
 
   // Rewrite the results to be arrays in session.fields order, rather than objects
   const fields = session.fields;
+
   const resultsAsArrays = results.map((row) => {
-    let rowArray = fields.map((fieldName) => {
-      return row[fieldName];
+    let rowArray = fields.map((field) => {
+      return row[field.name];
     });
     return rowArray;
   });

--- a/lib/importer/views/plugin_config.html
+++ b/lib/importer/views/plugin_config.html
@@ -67,7 +67,7 @@
           <input type="hidden" name="field" value="{{field}}"/>
           <li class="govuk-task-list__item govuk-task-list__item--with-link">
             <div class="govuk-task-list__name-and-hint">
-                {{field}}
+                {{field.name}}
             </div>
             <div class="govuk-task-list__status" id="company-details-1-status">
               <button type="submit" class="govuk-button govuk-button--warning govuk-!-static-margin-bottom-0" data-module="govuk-button">Delete</button>

--- a/lib/importer/views/plugin_config.html
+++ b/lib/importer/views/plugin_config.html
@@ -65,7 +65,7 @@
         {% for field in config.fields %}
         <form action="config/field" method="post">
           <input type="hidden" name="action" value="delete"/>
-          <input type="hidden" name="field" value="{{field}}"/>
+          <input type="hidden" name="field" value="{{field.name}}"/>
           <li class="govuk-task-list__item">
             <div class="govuk-grid-column-one-quarter">
                 {{field.name}}

--- a/lib/importer/views/plugin_config.html
+++ b/lib/importer/views/plugin_config.html
@@ -59,17 +59,27 @@
       </p>
     </div>
 
-    <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
       <ul class="govuk-task-list">
         {% for field in config.fields %}
         <form action="config/field" method="post">
           <input type="hidden" name="action" value="delete"/>
           <input type="hidden" name="field" value="{{field}}"/>
-          <li class="govuk-task-list__item govuk-task-list__item--with-link">
-            <div class="govuk-task-list__name-and-hint">
+          <li class="govuk-task-list__item">
+            <div class="govuk-grid-column-one-quarter">
                 {{field.name}}
             </div>
-            <div class="govuk-task-list__status" id="company-details-1-status">
+
+            <div class="govuk-grid-column-one-quarter govuk-!-text-align-centre">
+              {{field.type}}
+            </div>
+
+            <div class="govuk-grid-column-one-quarter govuk-!-text-align-centre">
+              {% if field.required %}required{% else %}optional{% endif %}
+            </div>
+
+            <div class="govuk-grid-column-one-quarter govuk-!-text-align-right">
               <button type="submit" class="govuk-button govuk-button--warning govuk-!-static-margin-bottom-0" data-module="govuk-button">Delete</button>
             </div>
           </li>
@@ -83,6 +93,7 @@
       </div>
 
     </div>
+  </div>
 
     <div class="govuk-grid-column-full govuk-!-padding-top-6" >
       <h2 class="govuk-heading-l">Save changes</h2>

--- a/lib/importer/views/plugin_config_add_field.html
+++ b/lib/importer/views/plugin_config_add_field.html
@@ -54,6 +54,42 @@
         <input class="govuk-input" id="field-name" name="field" type="text">
       </div>
 
+      <div class="govuk-form-group">
+        <label class="govuk-label" for="field-type">
+          Field type
+        </label>
+        <div id="type-hint" class="govuk-hint">
+          Select what type of field is expected
+        </div>
+        <select class="govuk-select" id="field-type" name="type">
+          <option value="text">Text</option>
+          <option value="number">Number</option>
+        </select>
+      </div>
+
+      <div class="govuk-form-group">
+        <div class="govuk-radios" data-module="govuk-radios">
+          <label class="govuk-label" for="field-type">
+            Required or Optional
+          </label>
+          <div id="type-hint" class="govuk-hint">
+            Choose whether the field is required or optional
+          </div>
+          <div class="govuk-radios__item">
+            <input class="govuk-radios__input" id="field-required-optional" name="required" type="radio" value="false" selected="selected">
+            <label class="govuk-label govuk-radios__label" for="field-required-optional">
+              Optional
+            </label>
+          </div>
+          <div class="govuk-radios__item">
+            <input class="govuk-radios__input" id="field-required-required" name="required" type="radio" value="true">
+            <label class="govuk-label govuk-radios__label" for="field-required-required">
+              Required
+            </label>
+          </div>
+        </div>
+      </div>
+
       <div class="govuk-button-group">
         <input type="submit" class="govuk-button" value="Add"/>
         <a class="govuk-link" href="/importer/config">Cancel</a>

--- a/prototypes/basic/package-lock.json
+++ b/prototypes/basic/package-lock.json
@@ -30,7 +30,7 @@
         "@eslint/js": "^9.13.0",
         "eslint": "^9.19.0",
         "eslint-plugin-jest": "^28.11.0",
-        "globals": "^15.14.0",
+        "globals": "^16.0.0",
         "jest": "^29.7.0",
         "mock-fs": "^5.5.0"
       }

--- a/prototypes/basic/tests/tribbles.spec.js
+++ b/prototypes/basic/tests/tribbles.spec.js
@@ -98,10 +98,23 @@ test('trouble with tribbles', async ({ page }) => {
 
     await mapping.setMapping('Name', 'Title')
     await mapping.setMapping('Colour', 'First name')
-    await mapping.setMapping('Markings', 'Surname')
+    await mapping.setMapping('Weight', 'Salary')
     await mapping.submit()
 
     // ---------------------------------------------------------------------------
-    // Should be on the review page
+    // Should be on the review page and we want to check that the total number of rows,
+    // sum of salaries and avg of salaries is correct
     await expect(page).toHaveURL(/.review/)
+
+    let amounts = new Array()
+    let amountCount = await page.locator("ul.govuk-list--bullet li strong").count();
+    for (let idx = 0; idx < amountCount; idx++) {
+        let amt = await page.locator("ul.govuk-list--bullet li strong").nth(idx).textContent()
+        amounts.push(amt)
+    }
+
+    expect(amounts).toStrictEqual([
+        "6", "£36", "£6"
+    ])
+
 });


### PR DESCRIPTION
Changes configuration so that instead of just having a field name, it now accepts a field type (string or number) and a boolean which suggests whether the field is required in the mapping or not.

The codebase still supports the old style configuration (fields are a list of names) but defaults to not-required and string fields.

The new configuration structure looks like 

```
[
    { name: "Fieldname", type: "string", required: false }
]
```

where type can currently be one of "string" or "number"