### PR TITLE
Update test/default prototype

### DIFF
--- a/lib/importer/src/index.js
+++ b/lib/importer/src/index.js
@@ -208,8 +208,72 @@ exports.Initialise = (config, router, prototypeKit) => {
       headers: headers,
       totalCount: mapResults.totalCount,
       extraRecordCount: mapResults.extraRecordCount,
+      errorCount: mapResults.errorCount,
+      warningCount: mapResults.warningCount,
     };
   });
+
+  //--------------------------------------------------------------------
+  // Helper functions that can be used on the review page to show
+  // information about the data that has been mapped.
+  //--------------------------------------------------------------------
+  prototypeKit.views.addFunction(
+    "data_sum",
+    (data, column) => {
+      const session = data[IMPORTER_SESSION_KEY];
+      const mapResults = sheets_lib.MapData(session);
+      const headers = session.fields;
+
+      const idx = headers.findIndex((x) => x == column)
+      if (idx == -1) {
+        return "No data found"
+      }
+
+      let numbers = mapResults.resultRecords
+        .filter((x) => x !== undefined && x[idx] !== undefined)
+        .map((x) => { console.log(x); return x[idx].match(/\d+/g).join("") })
+        .map((x) => parseInt(x))
+
+      return numbers.reduce((acc, i) => acc + i, 0)
+    },
+    {},
+  );
+
+  prototypeKit.views.addFunction(
+    "data_avg",
+    (data, column) => {
+      const session = data[IMPORTER_SESSION_KEY];
+      const mapResults = sheets_lib.MapData(session);
+      const headers = session.fields;
+
+      const idx = headers.findIndex((x) => x == column)
+      if (idx == -1) {
+        return "No data found"
+      }
+
+      const numbers = mapResults.resultRecords
+        .filter((x) => x !== undefined && x[idx] !== undefined)
+        .map((x) => x[idx].match(/\d+/g).join(""))
+        .map((x) => parseInt(x))
+
+      const avg = numbers.reduce((acc, i) => acc + i, 0) / numbers.length
+      if (Number.isNaN(avg)) {
+        return "0"
+      }
+      return avg
+    },
+    {},
+  );
+
+  prototypeKit.views.addFilter('currency', function (content) {
+    const num = parseInt(content)
+    if (num === undefined) {
+      return content
+    }
+
+    return "£" + num.toLocaleString()
+  })
+
 
   //--------------------------------------------------------------------
   // Redirects the current request to the 'next' URL after decoding the

--- a/lib/importer/src/index.js
+++ b/lib/importer/src/index.js
@@ -213,6 +213,20 @@ exports.Initialise = (config, router, prototypeKit) => {
     };
   });
 
+
+  const parseNumberFromString = (s) => {
+    const parsed = s.match(/([0-9]*\.[0-9]+|[0-9]+)/)
+    if (parsed == null) {
+      return 0
+    }
+
+    if (parsed[0].indexOf(".") >= 0) {
+      return parseFloat(parsed[0])
+    }
+
+    return parseInt(parsed[0])
+  }
+
   //--------------------------------------------------------------------
   // Helper functions that can be used on the review page to show
   // information about the data that has been mapped.
@@ -231,8 +245,8 @@ exports.Initialise = (config, router, prototypeKit) => {
 
       let numbers = mapResults.resultRecords
         .filter((x) => x !== undefined && x[idx] !== undefined)
-        .map((x) => { console.log(x); return x[idx].match(/\d+/g).join("") })
-        .map((x) => parseInt(x))
+        .map((x) => parseNumberFromString(x[idx]))
+
 
       return numbers.reduce((acc, i) => acc + i, 0)
     },
@@ -253,8 +267,7 @@ exports.Initialise = (config, router, prototypeKit) => {
 
       const numbers = mapResults.resultRecords
         .filter((x) => x !== undefined && x[idx] !== undefined)
-        .map((x) => x[idx].match(/\d+/g).join(""))
-        .map((x) => parseInt(x))
+        .map((x) => parseNumberFromString(x[idx]))
 
       const avg = numbers.reduce((acc, i) => acc + i, 0) / numbers.length
       if (Number.isNaN(avg)) {

--- a/lib/importer/src/index.js
+++ b/lib/importer/src/index.js
@@ -31,6 +31,7 @@ exports.Initialise = (config, router, prototypeKit) => {
   // remember errors after they have been shown,
   //--------------------------------------------------------------------
   const cleanRequest = (request) => {
+    delete request.session.data['reference_number'];
     delete request.session.data[IMPORTER_ERROR_KEY];
   };
 
@@ -391,6 +392,8 @@ exports.Initialise = (config, router, prototypeKit) => {
 
       session.mapping = request.body;
 
+      request.session.data['reference_number'] = session.id.match(/\d+/g).join("").substring(0, 8);
+
       // Ensure the session is persisted. Currently in session, eventually another way
       request.session.data[IMPORTER_SESSION_KEY] = session;
       redirectOnwards(request, response);
@@ -411,6 +414,7 @@ exports.Initialise = (config, router, prototypeKit) => {
         response.status(404);
         return;
       }
+
       redirectOnwards(request, response);
     },
   );

--- a/prototypes/basic/app/assets/sass/application.scss
+++ b/prototypes/basic/app/assets/sass/application.scss
@@ -1,7 +1,7 @@
 //
 // For guidance on how to add CSS and SCSS see:
 // https://prototype-kit.service.gov.uk/docs/adding-css-javascript-and-images
-// 
+//
 
 // Add extra styles here
 
@@ -14,4 +14,14 @@ pre {
     box-shadow: 0px 0px 16px #ddd;
     max-height: 400px;
     overflow-y: scroll;
+}
+
+.contextual-sidebar {
+    border-top: 2px solid #1d70b8;
+    padding-top: 1em;
+}
+
+.contextual-sidebar .subsection {
+    border-top: 1px solid #b1b4b6;
+    padding-top: 1em;
 }

--- a/prototypes/basic/app/config.json
+++ b/prototypes/basic/app/config.json
@@ -7,6 +7,7 @@
     "Employee number",
     "Employment start date",
     "Salary",
+    "Contribution percentage",
     "Payment date"
   ]
 }

--- a/prototypes/basic/app/config.json
+++ b/prototypes/basic/app/config.json
@@ -6,7 +6,7 @@
     "Surname",
     "Employee number",
     "Employment start date",
-    "Salary (pounds)",
+    "Salary",
     "Payment date"
   ]
 }

--- a/prototypes/basic/app/config.json
+++ b/prototypes/basic/app/config.json
@@ -1,4 +1,12 @@
 {
-  "serviceName": "Import spreadsheet data",
-  "fields": ["Code", "Name", "Speciality"]
+  "serviceName": "Upload monthly pension return",
+  "fields": [
+    "Title",
+    "First name",
+    "Surname",
+    "Employee number",
+    "Employment start date",
+    "Salary (pounds)",
+    "Payment date"
+  ]
 }

--- a/prototypes/basic/app/filters.js
+++ b/prototypes/basic/app/filters.js
@@ -7,4 +7,13 @@ const govukPrototypeKit = require('govuk-prototype-kit')
 const addFilter = govukPrototypeKit.views.addFilter
 
 // Add your filters here
+addFilter('lastMonthRange', function (content) {
+    var lastMonth = new Date();
+    lastMonth.setDate(0)
 
+    if (content == "start") {
+        lastMonth.setDate(1)
+    }
+
+    return lastMonth.toLocaleDateString('en-gb', { weekday: "long", year: "numeric", month: "short", day: "numeric" })
+})

--- a/prototypes/basic/app/views/index.html
+++ b/prototypes/basic/app/views/index.html
@@ -24,10 +24,33 @@
     </p>
 
     <p class="govuk-body">
-      sdfsdfsdf
+      By uploading your pension returns on a monthly basis we are able to keep
+      current data and future projections up to date, ensuring that you and your
+      staff are kept as up to date as possible
     </p>
 
-    <p class="govuk-body">govuk-body</p>
+    <p class="govuk-body">
+      To begin, you will need a spreadsheet or comma-separated file containing the previous month's
+      employee salaries alongside their employee reference number and personal details. After uploading
+      your file you will need to choose which sheet contains the data, and then  you will need to tell
+      us which fields in your spreadsheet are associated with the following fields:
+
+        <ul class="govuk-list govuk-list--bullet">
+          <li>Title</li>
+          <li>First name</li>
+          <li>Surname</li>
+          <li>Employee number</li>
+          <li>Employment start date</li>
+          <li>Salary</li>
+          <li>Payment date</li>
+        </ul>
+      </p>
+    </p>
+
+    <p class="govuk-body">
+      On completion, you will be provided with a reference number for the upload which should be quoted
+      in any correspondence about this process.
+    </p>
 
     {{ govukButton({
       text: "Start now",

--- a/prototypes/basic/app/views/index.html
+++ b/prototypes/basic/app/views/index.html
@@ -8,9 +8,26 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+
     <h1 class="govuk-heading-xl">
-      {{ serviceName }}
+      Upload your monthly pension return
     </h1>
+
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <p class="govuk-body-l">
+      This service enables you to upload your monthly pension return as a
+      single spreadsheet so that you may submit multiple records in a single transaction.
+    </p>
+
+    <p class="govuk-body">
+      sdfsdfsdf
+    </p>
+
+    <p class="govuk-body">govuk-body</p>
 
     {{ govukButton({
       text: "Start now",
@@ -19,6 +36,24 @@
     })
     }}
   </div>
+
+  <div class="govuk-grid-column-one-third">
+    <div class="contextual-sidebar govuk-!-display-none-print">
+      <h2 class="govuk-heading-s">
+        Related content
+      </h2>
+
+      <nav aria-labelledby="related-nav-related_items-508b87a0" data-module="gem-toggle" data-gem-toggle-module-started="true">
+        <p class="govuk-body-s">
+          <ul class="govuk-list govuk-list--spaced">
+            <li><a class="govuk-link" href="/info#help">Pension reporting help</a></li>
+          </ul>
+          </p>
+      </nav>
+
+    </div>
+  </div>
+
 </div>
 
 {% endblock %}

--- a/prototypes/basic/app/views/info.html
+++ b/prototypes/basic/app/views/info.html
@@ -26,43 +26,83 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <p class="govuk-body">govuk-body</p>
-
     <p class="govuk-body">
-      <ul class="govuk-list govuk-list--bullet">
-        <li>apples</li>
-        <li>oranges</li>
-        <li>pears</li>
-      </ul>
+      Once you have uploaded your file, you will need to tell us which fields in your spreadsheet
+      are associated with the following fields:
+
+      <dl class="govuk-summary-list">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Title
+          </dt>
+          <dd class="govuk-summary-list__value">
+            Optional - The employee's title
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            First name
+          </dt>
+          <dd class="govuk-summary-list__value">
+            Required - The first name of the employee
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Surname
+          </dt>
+          <dd class="govuk-summary-list__value">
+            Required - The employee's family name
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Employee number
+          </dt>
+          <dd class="govuk-summary-list__value">
+            Optional - The employee's unique identifier, included in reports for your use
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Employment start date
+          </dt>
+          <dd class="govuk-summary-list__value">
+            Required - The date your employee's employment began, in yyyy-mm-dd format.
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Salary
+          </dt>
+          <dd class="govuk-summary-list__value">
+            Required - The employees salary for the current month, in GBP
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Contribution percentage
+          </dt>
+          <dd class="govuk-summary-list__value">
+            Required - Percentage contribution by employer
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Payment date
+          </dt>
+          <dd class="govuk-summary-list__value">
+            Required - The date that the employee received their salary for the current month
+          </dd>
+        </div>
+     </dl>
     </p>
 
-    <p class="govuk-body">govuk-body</p>
+    <p class="govuk-body">
+      Once you have selected the appropriate sheet, and told the system which is the header row,
+      you will be asked to associate each column in your headers with one of the values above.
+    </p>
   </div>
 </div>
-
-<div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-        <h2 id="help" class="govuk-heading-l">
-        Help
-        </h2>
-    </div>
-</div>
-
-<div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <p class="govuk-body">govuk-body</p>
-
-      <p class="govuk-body">
-        <ul class="govuk-list govuk-list--bullet">
-          <li>apples</li>
-          <li>oranges</li>
-          <li>pears</li>
-        </ul>
-      </p>
-
-      <p class="govuk-body">govuk-body</p>
-
-    </div>
-  </div>
 
 {% endblock %}

--- a/prototypes/basic/app/views/info.html
+++ b/prototypes/basic/app/views/info.html
@@ -1,0 +1,68 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="Home" %}
+
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+
+{% block beforeContent %}
+{{ govukBackLink({
+  text: "Back",
+  href: "/"
+}) }}
+{% endblock %}
+
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <h1 class="govuk-heading-xl">
+      Information about reporting your organisation's pension returns
+    </h1>
+
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <p class="govuk-body">govuk-body</p>
+
+    <p class="govuk-body">
+      <ul class="govuk-list govuk-list--bullet">
+        <li>apples</li>
+        <li>oranges</li>
+        <li>pears</li>
+      </ul>
+    </p>
+
+    <p class="govuk-body">govuk-body</p>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <h2 id="help" class="govuk-heading-l">
+        Help
+        </h2>
+    </div>
+</div>
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <p class="govuk-body">govuk-body</p>
+
+      <p class="govuk-body">
+        <ul class="govuk-list govuk-list--bullet">
+          <li>apples</li>
+          <li>oranges</li>
+          <li>pears</li>
+        </ul>
+      </p>
+
+      <p class="govuk-body">govuk-body</p>
+
+    </div>
+  </div>
+
+{% endblock %}

--- a/prototypes/basic/app/views/layouts/main.html
+++ b/prototypes/basic/app/views/layouts/main.html
@@ -3,4 +3,6 @@ For guidance on how to use layouts see:
 https://prototype-kit.service.gov.uk/docs/how-to-use-layouts
 #}
 
+{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+
 {% extends "govuk-prototype-kit/layouts/govuk-branded.njk" %}

--- a/prototypes/basic/app/views/mapping.html
+++ b/prototypes/basic/app/views/mapping.html
@@ -41,9 +41,9 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
         <h1 class="govuk-heading-l">Identify columns</h1>
-        <p>
-            Select which columns in your sheet contain the information required
-            by this service. You can ignore any columns that contain information
+        <p class="govuk-body">
+            Select which columns from your sheet, which are shown on the left, contain the information required
+            by this service by choosing a value from the dropdown. You can ignore any columns that contain information
             that this service doesn't need.
         </p>
 

--- a/prototypes/basic/app/views/mapping.html
+++ b/prototypes/basic/app/views/mapping.html
@@ -1,8 +1,38 @@
 {% extends "layouts/main.html" %}
 
 {% block pageTitle %} {{ serviceName }} – GOV.UK Prototype Kit {% endblock %}
+
 {% block beforeContent %}
-{{ govukBackLink({ text: "Back", href: "javascript:window.history.back()" }) }}
+{{
+    govukBreadcrumbs({
+      items: [
+        {
+          text: "Home",
+          href: "/"
+        },
+        {
+            text: "Upload spreadsheet",
+            href: "/upload"
+        },
+        {
+          text: "Select sheet",
+          href: "/select_sheet"
+        },
+        {
+            text: "Select header row",
+            href: "/select_header_row"
+        },
+        {
+            text: "Select footer row",
+            href: "/select_footer_row"
+        },
+        {
+            text: "Identify columns",
+            href: "/mapping"
+        }
+      ]
+    })
+  }}
 {% endblock %}
 
 {% from "importer/macros/field_mapper.njk" import importerFieldMapper %}

--- a/prototypes/basic/app/views/mapping.html
+++ b/prototypes/basic/app/views/mapping.html
@@ -49,7 +49,7 @@
 
         <h2 class="govuk-heading-m">{{sheet}}</h2>
 
-        <form action="{{ importerMapDataPath('/success') }}" method="post">
+        <form action="{{ importerMapDataPath('/review') }}" method="post">
 
             {{ importerFieldMapper(data) }}
 

--- a/prototypes/basic/app/views/review.html
+++ b/prototypes/basic/app/views/review.html
@@ -2,6 +2,9 @@
 
 {% block pageTitle %} {{ serviceName }} – GOV.UK Prototype Kit {% endblock %}
 {% block beforeContent %}
+
+
+
 {{
     govukBreadcrumbs({
       items: [
@@ -62,6 +65,11 @@
         <p class="govuk-body">
             If the details above are correct you can continue to submit your return by clicking the 'Submit' button below.
         </p>
+
+        <p class="govuk-body">
+            If there were problems with the uploaded data, you should correct the issues and <a href="{{ importerStartPath('/upload') }}">re-upload the data</a>
+        </p>
+
 
         <form action="{{ importerReviewDataPath('/success') }}" method="post">
             <div class="govuk-button-group">

--- a/prototypes/basic/app/views/review.html
+++ b/prototypes/basic/app/views/review.html
@@ -2,13 +2,66 @@
 
 {% block pageTitle %} {{ serviceName }} – GOV.UK Prototype Kit {% endblock %}
 {% block beforeContent %}
-{{ govukBackLink({ text: "Back", href: "javascript:window.history.back()" }) }}
+{{
+    govukBreadcrumbs({
+      items: [
+        {
+          text: "Home",
+          href: "/"
+        },
+        {
+            text: "Upload spreadsheet",
+            href: "/upload"
+        },
+        {
+          text: "Select sheet",
+          href: "/select_sheet"
+        },
+        {
+            text: "Select header row",
+            href: "/select_header_row"
+        },
+        {
+            text: "Select footer row",
+            href: "/select_footer_row"
+        },
+        {
+            text: "Identify columns",
+            href: "/mapping"
+        },
+        {
+            text: "Review data",
+            href: "/review"
+        }
+      ]
+    })
+  }}
 {% endblock %}
 
 {% block content %}
+{% set results = importerMappedData(data) %}
+
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
         <h1 class="govuk-heading-l">Review your data</h1>
+
+        <p class="govuk-body">
+            During import there were <strong>{{results.errorCount}}</strong> errors and <strong>{{results.warningCount}}</strong> warnings.
+        </p>
+
+        <p class="govuk-body">
+        The uploaded data contains the following data:
+
+            <ul class="govuk-list govuk-list--bullet">
+                <li><strong>{{ results.totalCount }}</strong> rows of data</li>
+                <li>a total salary commitment from the 'Salary' column of <strong>{{ data_sum(data, 'Salary') | currency }}</strong>.</li>
+                <li>an average salary from the 'Salary' column of <strong>{{ data_avg(data, 'Salary') | currency }}</strong>.</li>
+            </ul>
+        </p>
+
+        <p class="govuk-body">
+            If the details above are correct you can continue to submit your return by clicking the 'Submit' button below.
+        </p>
 
         <form action="{{ importerReviewDataPath('/success') }}" method="post">
             <div class="govuk-button-group">

--- a/prototypes/basic/app/views/select_footer_row.html
+++ b/prototypes/basic/app/views/select_footer_row.html
@@ -7,7 +7,32 @@
 {% block pageTitle %} {{ serviceName }} – GOV.UK Prototype Kit {% endblock %}
 
 {% block beforeContent %}
-{{ govukBackLink({ text: "Back", href: "javascript:window.history.back()" }) }}
+{{
+    govukBreadcrumbs({
+      items: [
+        {
+          text: "Home",
+          href: "/"
+        },
+        {
+            text: "Upload spreadsheet",
+            href: "/upload"
+        },
+        {
+          text: "Select sheet",
+          href: "/select_sheet"
+        },
+        {
+            text: "Select header row",
+            href: "/select_header_row"
+        },
+        {
+            text: "Select footer row",
+            href: "/select_footer_row"
+        }
+      ]
+    })
+  }}
 {% endblock %}
 
 {% from "importer/macros/footer_selector.njk" import importerFooterSelector %}

--- a/prototypes/basic/app/views/select_footer_row.html
+++ b/prototypes/basic/app/views/select_footer_row.html
@@ -44,11 +44,11 @@
             <h1 class="govuk-heading-l">
                 Select cells containing footers, counts or totals
             </h1>
-            <p>
+            <p class="govuk-body">
                 Select any extra information after the rows if your sheet
                 contains it. It won't be used for this service.
             </p>
-            <p>
+            <p class="govuk-body">
                 You can skip this step if your sheet doesn't contain any extra
                 information.
             </p>

--- a/prototypes/basic/app/views/select_header_row.html
+++ b/prototypes/basic/app/views/select_header_row.html
@@ -46,7 +46,9 @@
                 needed for this service.
             </p>
             <p class="govuk-body">
-                If you don't choose a column name,
+                If you don't choose a column name, then the first row of the table will
+                be used as headers. Any blank cells in that row will be labelled as
+                "Untitled column" with a number that incrememts for each blank cell. e.g. "[Untitled column 1]"
         </legend>
 
         <form action="{{ importerSelectHeaderPath('/select_footer_row') }}" method="post">

--- a/prototypes/basic/app/views/select_header_row.html
+++ b/prototypes/basic/app/views/select_header_row.html
@@ -40,12 +40,9 @@
             <h1 class="govuk-heading-l">
                 Select cells containing column names
             </h1>
-            <p>
+            <p class="govuk-body-l">
                 Column names are the descriptive labels usually found at the top
-                of a column.
-            </p>
-            <p>
-                You can select a whole row or just the column names that are
+                of a column. You can select a whole row or just the column names that are
                 needed for this service.
             </p>
         </legend>

--- a/prototypes/basic/app/views/select_header_row.html
+++ b/prototypes/basic/app/views/select_header_row.html
@@ -7,7 +7,28 @@
 {% block pageTitle %} {{ serviceName }} – GOV.UK Prototype Kit {% endblock %}
 
 {% block beforeContent %}
-{{ govukBackLink({ text: "Back", href: "javascript:window.history.back()" }) }}
+{{
+    govukBreadcrumbs({
+      items: [
+        {
+          text: "Home",
+          href: "/"
+        },
+        {
+            text: "Upload spreadsheet",
+            href: "/upload"
+        },
+        {
+          text: "Select sheet",
+          href: "/select_sheet"
+        },
+        {
+            text: "Select header row",
+            href: "/select_header_row"
+        }
+      ]
+    })
+  }}
 {% endblock %}
 
 {% from "importer/macros/header_selector.njk" import importerHeaderSelector %}

--- a/prototypes/basic/app/views/select_header_row.html
+++ b/prototypes/basic/app/views/select_header_row.html
@@ -45,6 +45,8 @@
                 of a column. You can select a whole row or just the column names that are
                 needed for this service.
             </p>
+            <p class="govuk-body">
+                If you don't choose a column name,
         </legend>
 
         <form action="{{ importerSelectHeaderPath('/select_footer_row') }}" method="post">

--- a/prototypes/basic/app/views/select_sheet.html
+++ b/prototypes/basic/app/views/select_sheet.html
@@ -3,8 +3,26 @@
 {% from "importer/macros/sheet_selector.njk" import importerSheetSelector %}
 
 {% block pageTitle %} {{ serviceName }} – GOV.UK Prototype Kit {% endblock %}
+
 {% block beforeContent %}
-{{ govukBackLink({ text: "Back", href: "javascript:window.history.back()" }) }}
+{{
+    govukBreadcrumbs({
+      items: [
+        {
+          text: "Home",
+          href: "/"
+        },
+        {
+            text: "Upload spreadsheet",
+            href: "/upload"
+        },
+        {
+          text: "Select sheet",
+          href: "/select_sheet"
+        }
+      ]
+    })
+  }}
 {% endblock %}
 
 {% block content %}

--- a/prototypes/basic/app/views/select_sheet.html
+++ b/prototypes/basic/app/views/select_sheet.html
@@ -36,6 +36,12 @@
               Which sheet do you wish to import?
             </h1>
           </legend>
+
+          <p class="govuk-body-l">
+            Select the name of the sheet below which will give you the opportunity to confirm that
+            it is the sheet containing the relevant data.
+          </p>
+
           <div class="govuk-radios" data-module="govuk-radios">
             {{ importerSheetSelector(data) }}
           </div>

--- a/prototypes/basic/app/views/success.html
+++ b/prototypes/basic/app/views/success.html
@@ -32,6 +32,11 @@
           If you have any queries about the process or the data uploaded, please quote your reference number in
           any communications.
         </p>
+
+        <p class="govuk-body">
+          To upload more data in another return, <a href="/">start again</a>
+
+        </p>
       </div>
     </div>
   </main>

--- a/prototypes/basic/app/views/success.html
+++ b/prototypes/basic/app/views/success.html
@@ -15,13 +15,22 @@
             Upload complete
           </h1>
           <div class="govuk-panel__body">
-            Your reference number<br><strong>{{session.id}}</strong>
+            Your reference number: <br><strong>{{ data['reference_number'] }}</strong>
           </div>
         </div>
-        <p class="govuk-body">You have successfully uploaded a spreadsheet</p>
+        <p class="govuk-body-l">You have successfully uploaded a spreadsheet</p>
         <h2 class="govuk-heading-m">What happens next</h2>
         <p class="govuk-body">
-          Data things
+          Data submitted through this service will be processed within the next
+          24 hours and shown on your organisation dashboard shortly afterwards.
+        </p>
+        <p class="govuk-body">
+          If you re-submit a modified version of this data within the next 28 days it will replace the current values,
+          after which you must contact us for support.
+        </p>
+        <p class="govuk-body">
+          If you have any queries about the process or the data uploaded, please quote your reference number in
+          any communications.
         </p>
       </div>
     </div>

--- a/prototypes/basic/app/views/upload.html
+++ b/prototypes/basic/app/views/upload.html
@@ -4,7 +4,20 @@
 
 {% block pageTitle %} {{ serviceName }} – GOV.UK Prototype Kit {% endblock %}
 {% block beforeContent %}
-{{ govukBackLink({ text: "Back", href: "javascript:window.history.back()" }) }}
+{{
+    govukBreadcrumbs({
+      items: [
+        {
+          text: "Home",
+          href: "/"
+        },
+        {
+            text: "Upload spreadsheet",
+            href: "/upload"
+        }
+      ]
+    })
+  }}
 {% endblock %}
 
 {% block content %}
@@ -12,12 +25,35 @@
     <div class="govuk-grid-column-two-thirds">
         <h1 class="govuk-heading-l">Upload your data</h1>
 
+        <p class="govuk-body">
+          The expected pay period is from <strong>{{ "start" | lastMonthRange }}</strong> to <strong>{{ "end" | lastMonthRange }}</strong>,
+          and all of the dates in this file should be in that range (inclusive).
+          Any rows with dates outside of that range will not be processed.
+        </p>
+
+        <div class="govuk-inset-text">
+          <h1 class="govuk-heading-s">Check your dates</h1>
+          <p class="govuk-body">
+            Before you upload the data, you should check the dates are formatted as yyyy-mm-dd (e.g. 2025-02-28).
+          </p>
+        </div>
+
+        <p class="govuk-body">
+          The file you upload must be in one of the following formats, but you will be given the opportunity to choose which
+          sheet contains the data, and which columns contain the required fields.
+          <ul class="govuk-list govuk-list--bullet">
+            <li>Comma-separated values - CSV</li>
+            <li>Microsoft Office - XLSX or XLS</li>
+            <li>Open office document - ODS</li>
+          </ul>
+        </p>
+
         <form action="{{importerUploadPath('/select_sheet')}}" method="POST" enctype="multipart/form-data">
             <div>
                 {{ govukFileUpload({
                 id: "file-upload",
                 name: "file",
-                label: { text: "Upload an XLSX, ODS, or CSV file"},
+                label: { text: "Choose a file"},
                 attributes: { "accept":
                 ".xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.csv,text/csv,application/vnd.oasis.opendocument.spreadsheet,.ods"},
                 errorMessage: importerError(data)
@@ -25,7 +61,7 @@
                 }}
             </div>
             <div class="govuk-button-group">
-                {{ govukButton({ text: "Upload" }) }}
+                {{ govukButton({ text: "Upload data" }) }}
             </div>
         </form>
     </div>

--- a/prototypes/basic/app/views/upload.html
+++ b/prototypes/basic/app/views/upload.html
@@ -44,7 +44,7 @@
           <ul class="govuk-list govuk-list--bullet">
             <li>Comma-separated values - CSV</li>
             <li>Microsoft Office - XLSX or XLS</li>
-            <li>Open office document - ODS</li>
+            <li>OpenDocument Spreadsheet - ODS</li>
           </ul>
         </p>
 

--- a/prototypes/basic/tests/simple.spec.js
+++ b/prototypes/basic/tests/simple.spec.js
@@ -4,5 +4,5 @@ test('has title', async ({ page }) => {
   await page.goto('/');
 
   // Expect a title "to contain" a substring.
-  await expect(page).toHaveTitle(/Import spreadsheet data/);
+  await expect(page).toHaveTitle(/Upload monthly pension return/);
 });

--- a/prototypes/basic/tests/small-file.spec.js
+++ b/prototypes/basic/tests/small-file.spec.js
@@ -11,7 +11,7 @@ import { MappingPage } from './helpers/mapping_page'
 const path = require('node:path');
 
 // Take a screenshot to help with debugging
-const screenshot = async(page, name) => {
+const screenshot = async (page, name) => {
     await page.screenshot({ path: name, fullPage: true });
 }
 
@@ -46,7 +46,7 @@ test('tiny files', async ({ page }) => {
     // // Check the data is present in the sheet previews
     const previewRow = await sheets.getTableRow(0, 0)
     const zerozero = await previewRow.locator("td").nth(0).textContent()
-    const zeroone =  await previewRow.locator("td").nth(1).textContent()
+    const zeroone = await previewRow.locator("td").nth(1).textContent()
     await expect(zerozero).toBe("A")
     await expect(zeroone).toBe("B")
 
@@ -58,7 +58,7 @@ test('tiny files', async ({ page }) => {
     await expect(page).toHaveURL(/.select_header_row/)
 
     const headers = new HeaderSelectorPage(page)
-    await headers.select([0,0], [0,1])
+    await headers.select([0, 0], [0, 1])
     await headers.submit()
 
     // // ---------------------------------------------------------------------------
@@ -71,7 +71,6 @@ test('tiny files', async ({ page }) => {
     // // ---------------------------------------------------------------------------
     // // Perform the mapping after checking the previews here are what we expect
     await expect(page).toHaveURL(/.mapping/)
-
     const mapping = new MappingPage(page)
 
     const expectedColumns = ["A", "B"]
@@ -86,8 +85,8 @@ test('tiny files', async ({ page }) => {
     const examples = await mapping.getExamples()
     expect(examples).toStrictEqual(expectedExamples)
 
-    await mapping.setMapping('A', 'Code')
-    await mapping.setMapping('B', 'Name')
+    await mapping.setMapping('A', 'Title')
+    await mapping.setMapping('B', 'Surname')
     await mapping.submit()
 
     // // ---------------------------------------------------------------------------

--- a/prototypes/basic/tests/small-file.spec.js
+++ b/prototypes/basic/tests/small-file.spec.js
@@ -91,5 +91,5 @@ test('tiny files', async ({ page }) => {
 
     // // ---------------------------------------------------------------------------
     // // Should be on the success page
-    await expect(page).toHaveURL(/.success/)
+    await expect(page).toHaveURL(/.review/)
 });

--- a/prototypes/basic/tests/tribbles.spec.js
+++ b/prototypes/basic/tests/tribbles.spec.js
@@ -17,7 +17,7 @@ const sheetPreviewVisibility = new Map([
 ]);
 
 // Take a screenshot to help with debugging
-const screenshot = async(page, name) => {
+const screenshot = async (page, name) => {
     await page.screenshot({ path: name, fullPage: true });
 }
 
@@ -64,7 +64,7 @@ test('trouble with tribbles', async ({ page }) => {
     await expect(page).toHaveURL(/.select_header_row/)
 
     const headers = new HeaderSelectorPage(page)
-    await headers.select([2,0], [2,5])
+    await headers.select([2, 0], [2, 5])
     await headers.submit()
 
     // ---------------------------------------------------------------------------
@@ -96,9 +96,9 @@ test('trouble with tribbles', async ({ page }) => {
     const examples = await mapping.getExamples()
     expect(examples).toStrictEqual(expectedExamples)
 
-    await mapping.setMapping('Name', 'Code')
-    await mapping.setMapping('Colour', 'Name')
-    await mapping.setMapping('Markings', 'Speciality')
+    await mapping.setMapping('Name', 'Title')
+    await mapping.setMapping('Colour', 'First name')
+    await mapping.setMapping('Markings', 'Surname')
     await mapping.submit()
 
     // ---------------------------------------------------------------------------

--- a/prototypes/basic/tests/tribbles.spec.js
+++ b/prototypes/basic/tests/tribbles.spec.js
@@ -102,6 +102,6 @@ test('trouble with tribbles', async ({ page }) => {
     await mapping.submit()
 
     // ---------------------------------------------------------------------------
-    // Should be on the success page
-    await expect(page).toHaveURL(/.success/)
+    // Should be on the review page
+    await expect(page).toHaveURL(/.review/)
 });


### PR DESCRIPTION
Modified the test prototype to represent the process of a monthly pension return service where users can upload a spreadsheet of salary information for processing. 

It re-introduces the review page with some information (sum and average of the salaries provided) as a starting point for operations on the uploaded data.  A new info page is added which is linked on the newly updated start page.