### PR TITLE
Remove branding and clarify status of the demo

### DIFF
--- a/prototypes/basic/app/assets/sass/application.scss
+++ b/prototypes/basic/app/assets/sass/application.scss
@@ -5,6 +5,13 @@
 
 // Add extra styles here
 
+* {
+    font-family: Helvetica, Arial, sans-serif !important;
+}
+
+.govuk-header__logotype {
+    display: none;
+}
 
 pre {
     border: solid 2px #666;

--- a/prototypes/basic/app/views/layouts/main.html
+++ b/prototypes/basic/app/views/layouts/main.html
@@ -4,5 +4,36 @@ https://prototype-kit.service.gov.uk/docs/how-to-use-layouts
 #}
 
 {% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+{% from "govuk/components/header/macro.njk" import govukHeader %}
+
+{% block header %}
+  {{ govukHeader({
+    homepageUrl: "/",
+    serviceName: serviceName,
+    serviceUrl: "/",
+    containerClasses: "govuk-width-container"
+  }) }}
+
+  <div class="govuk-grid-row govuk-width-container">
+    <div class="govuk-grid-column-one-third">&nbsp;</div>
+    <div class="govuk-grid-column-full">
+
+  <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+    <div class="govuk-notification-banner__header">
+      <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+        Demonstration
+      </h2>
+    </div>
+    <div class="govuk-notification-banner__content">
+      <p class="govuk-notification-banner__heading">
+        This is a demonstration service for <a href="https://www.register-dynamics.co.uk/blog/why-services-suck-at-spreadsheets">"A thousand things at once: bulk transactions and data collection in digital services"</a> given at Services Week 2025
+      </p>
+    </div>
+  </div>
+  </div>
+  </div>
+
+
+{% endblock %}
 
 {% extends "govuk-prototype-kit/layouts/govuk-branded.njk" %}


### PR DESCRIPTION

* Removes the crown image from the header
* Changes the font to not use Transport (the default for prototype kit)
* Adds a warning message to every page clarifying that it is demonstration site

![Upload_monthly_pension_return_–_GOV_UK_Prototype_Kit](https://github.com/user-attachments/assets/59307899-8ffe-4baf-a2b3-34d3d488d14a)

Feedback on content/styling welcome.