### PR TITLE
Publish package on push

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,7 @@
 name: Publish package to GitHub Packages
-on: push #branches: [ main ]
+on:
+  push:
+    branches: [ main ]
 jobs:
   build:
     defaults:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,7 @@
-name: Publish package to GitHub Packages
+name: Publish package to GitHub Packages on tag
 on:
-  push:
-    branches: [ main ]
+  release:
+    types: [ published ]
 jobs:
   build:
     defaults:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,5 @@
 name: Publish package to GitHub Packages
-on:
-  push:
-    branches: [ main ]
+on: push #branches: [ main ]
 jobs:
   build:
     defaults:
@@ -10,15 +8,15 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
+      id-token: write
     steps:
     - uses: actions/checkout@v4
+    # Setup .npmrc file to publish to npm
     - uses: actions/setup-node@v4
       with:
         node-version: '20.x'
-        registry-url: 'https://npm.pkg.github.com'
-        scope: '@register-dynamics'
+        registry-url: 'https://registry.npmjs.org'
     - run: npm ci
-    - run: npm publish
+    - run: npm publish --provenance --access public
       env:
-        NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,7 @@
 name: Publish package to GitHub Packages
-on: push # branches: [ main ]
+on:
+  push:
+    branches: [ main ]
 jobs:
   build:
     defaults:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,22 @@
+name: Publish package to GitHub Packages
+on: push # branches: [ main ]
+jobs:
+  build:
+    defaults:
+      run:
+        working-directory: ./lib/importer
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version: '20.x'
+        registry-url: 'https://npm.pkg.github.com'
+        scope: '@register-dynamics'
+    - run: npm ci
+    - run: npm publish
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/lib/importer/.npmrc
+++ b/lib/importer/.npmrc
@@ -1,1 +1,1 @@
-@register-dynamics:registry=https://npm.pkg.github.com
+@register-dynamics:registry=https://registry.npmjs.org

--- a/lib/importer/.npmrc
+++ b/lib/importer/.npmrc
@@ -1,0 +1,1 @@
+@register-dynamics:registry=https://npm.pkg.github.com

--- a/lib/importer/package-lock.json
+++ b/lib/importer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@register-dynamics/importer",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@register-dynamics/importer",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {

--- a/lib/importer/package-lock.json
+++ b/lib/importer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@register-dynamics/importer",
-  "version": "0.1.2",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@register-dynamics/importer",
-      "version": "0.1.2",
+      "version": "0.1.1",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {

--- a/lib/importer/package.json
+++ b/lib/importer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@register-dynamics/importer",
-  "version": "0.1.2",
+  "version": "0.1.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/register-dynamics/data-import.git",
@@ -8,7 +8,7 @@
   },
   "owner": "register-dynamics",
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com"
+    "registry": "https://registry.npmjs.org"
   },
   "main": "src/index.js",
   "scripts": {

--- a/lib/importer/package.json
+++ b/lib/importer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@register-dynamics/importer",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/register-dynamics/data-import.git",


### PR DESCRIPTION
When merging to main, publish the lib/importer as a package to https://www.npmjs.com/package/@register-dynamics/importer

This github action only runs when a github release is published, so this PR does not involve itself in updating the package version in package.json.   

If in future we decide to publish multiple packages from here we can add a task to check both package.json have been updated and keep the versions in sync.