### PR TITLE
Manage collection of usage data

### DIFF
--- a/lib/importer/src/index.js
+++ b/lib/importer/src/index.js
@@ -344,10 +344,16 @@ exports.Initialise = (config, router, prototypeKit) => {
     router.get(
       IMPORTER_ROUTE_MAP.get("importerConfiguration"),
       (request, response) => {
+
+        // Record initialisation of the plugin
+        usageRecorder.recordEvent("Plugin configured")
+
+
         const pc = {
           config: {
             fields: plugin_config.fields
-          }
+          },
+          collectUsageData: usageRecorder.enabled,
         }
 
         // Copy flash message to template object and then remove from memory
@@ -374,6 +380,19 @@ exports.Initialise = (config, router, prototypeKit) => {
       IMPORTER_ROUTE_MAP.get("importerConfiguration"),
       (request, response) => {
         request.session.data['internal-message'] = "Configuration changes have been saved, and the application will restart shortly"
+
+        // Check the collectData value supplied, it'll either be the value or an array
+        // containing the value. The latter case appears to be extra junk submitted by
+        // the design system.
+        if (request.body.collectData == 'true' ||
+          (Array.isArray(request.body.collectData) &&
+            request.body.collectData.includes('true'))
+        ) {
+          usageRecorder.setPermission(true)
+        } else {
+          usageRecorder.setPermission(false)
+        }
+
 
         setTimeout(function () {
           plugin_config.persistConfig()

--- a/lib/importer/src/index.js
+++ b/lib/importer/src/index.js
@@ -30,11 +30,18 @@ const IMPORTER_ROUTE_MAP = new Map([
   ["importerConfigurationPath", "/importer/config/path"]
 ]);
 
+const usage = require("./usage.js")
+const usageRecorder = new usage.UsageCollection()
+
+
 exports.Initialise = (config, router, prototypeKit) => {
 
   const developmentMode = config.isDevelopment;
 
   const plugin_config = new conf.PluginConfig(config);
+
+  // Record initialisation of the plugin
+  usageRecorder.recordEvent("Plugin initialised")
 
   //--------------------------------------------------------------------
   // To be able to add a local views folder, we need to update the

--- a/lib/importer/src/index.js
+++ b/lib/importer/src/index.js
@@ -6,6 +6,7 @@ const session_lib = require("./session.js");
 const sheets_lib = require("./sheets.js");
 const tpl_functions = require("./functions.js")
 const tpl_filters = require("./filters.js")
+const usage = require("./usage.js")
 
 const IMPORTER_SESSION_KEY = "importer.session";
 const IMPORTER_ERROR_KEY = "importer.error";
@@ -30,17 +31,13 @@ const IMPORTER_ROUTE_MAP = new Map([
   ["importerConfigurationPath", "/importer/config/path"]
 ]);
 
-const usage = require("./usage.js")
-const usageRecorder = new usage.UsageCollection()
-
-
 exports.Initialise = (config, router, prototypeKit) => {
 
   const developmentMode = config.isDevelopment;
 
   const plugin_config = new conf.PluginConfig(config);
 
-  usageRecorder.explain()
+  const usageRecorder = new usage.UsageCollection(plugin_config)
 
   // Record initialisation of the plugin
   usageRecorder.recordEvent("Plugin initialised")

--- a/lib/importer/src/index.js
+++ b/lib/importer/src/index.js
@@ -40,6 +40,8 @@ exports.Initialise = (config, router, prototypeKit) => {
 
   const plugin_config = new conf.PluginConfig(config);
 
+  usageRecorder.explain()
+
   // Record initialisation of the plugin
   usageRecorder.recordEvent("Plugin initialised")
 

--- a/lib/importer/src/usage.js
+++ b/lib/importer/src/usage.js
@@ -52,7 +52,7 @@ const updateDUDKPermission = (dudkPermission) => {
     const data = fs.readFileSync(usage_config);
 
     const obj = JSON.parse(data)
-    obj.ddukCollectUsageData = ddukPermission
+    obj.ddukCollectUsageData = dudkPermission
 
     fs.writeFileSync(usage_config, JSON.stringify(obj))
 }

--- a/lib/importer/src/usage.js
+++ b/lib/importer/src/usage.js
@@ -16,7 +16,8 @@ const path = require('node:path');
 exports.UsageCollection = class {
     constructor() {
         const settings = usageCollectionSettings()
-        this.enabled = settings.collectUsageData && !settings.disableImporterUsageData
+        this.disableImporterUsageData = settings.disableImporterUsageData
+        this.enabled = settings.collectUsageData && !this.disableImporterUsageData
         this.clientId = settings.clientId
     }
 
@@ -26,6 +27,28 @@ exports.UsageCollection = class {
         //TODO: Actually record the usage against eventName
 
         return eventName != ""
+    }
+
+    // If tracking is currently enabled, ensure we explain to the user how they can
+    // turn it off if they wish to do so.
+    explain() {
+        if (!this.enabled) return;
+        if (this.disableImporterUsageData == true) return;
+
+        const explanation = [
+            "You are currently sending anonymous usage data to the prototype kit team.",
+            "In addition to this, anonymous usage data is also being sent to the authors",
+            "of the Data Upload Design Kit.",
+            "Should you wish to disable this you can do so by adding",
+            "",
+            "    disableImporterUsageData: true",
+            "",
+            "to the usage-data-config.json file in the prototype's directory.",
+            "", "",
+
+        ]
+
+        console.log(explanation.join('\n'));
     }
 }
 

--- a/lib/importer/src/usage.js
+++ b/lib/importer/src/usage.js
@@ -1,0 +1,39 @@
+//--------------------------------------------------------------------
+// This class handles the recording of usage data where the user
+// has enabled data collection for the prototype and not explicitly
+// disabled it for the plugin.
+//
+// Once constructed the class can be used to `recordEvent` but
+// will check it is enabled before doing anything to ensure the
+// user's preferences are respected and correctly applied.
+//--------------------------------------------------------------------
+
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+
+exports.UsageCollection = class {
+    constructor() {
+        const settings = usageCollectionSettings()
+        this.enabled = settings.collectUsageData && !settings.disableImporterUsageData
+        this.clientId = settings.clientId
+    }
+
+    recordEvent(eventName) {
+        if (!this.enabled) return false;
+
+        //TODO: Actually record the usage against eventName
+
+        return eventName != ""
+    }
+}
+
+const usageCollectionSettings = () => {
+    const projectDir = path.resolve(
+        process.env.KIT_PROJECT_DIR || process.cwd(),
+    );
+    const usage_config = path.join(projectDir, "usage-data-config.json")
+    const data = fs.readFileSync(usage_config);
+    return JSON.parse(data)
+}

--- a/lib/importer/src/usage.js
+++ b/lib/importer/src/usage.js
@@ -21,7 +21,7 @@ exports.UsageCollection = class {
     }
 
     setPermission(perm) {
-        updateDDUKPermission(perm)
+        updateDUDKPermission(perm)
         this.enabled = perm
     }
 
@@ -30,6 +30,7 @@ exports.UsageCollection = class {
 
         //TODO: Actually record the usage against eventName
         console.log("EVENT: " + eventName)
+
         return eventName != ""
     }
 }
@@ -43,7 +44,7 @@ const prototypeKitUsageCollectionSettings = () => {
     return JSON.parse(data)
 }
 
-const updateDDUKPermission = (ddukPermission) => {
+const updateDUDKPermission = (dudkPermission) => {
     const projectDir = path.resolve(
         process.env.KIT_PROJECT_DIR || process.cwd(),
     );

--- a/lib/importer/src/usage.js
+++ b/lib/importer/src/usage.js
@@ -15,10 +15,9 @@ const path = require('node:path');
 
 exports.UsageCollection = class {
     constructor() {
-        const settings = usageCollectionSettings()
-        this.disableImporterUsageData = settings.disableImporterUsageData
-        this.enabled = settings.collectUsageData && !this.disableImporterUsageData
+        const settings = prototypeKitUsageCollectionSettings()
         this.clientId = settings.clientId
+        this.enabled = settings.ddukCollectUsageData
     }
 
     recordEvent(eventName) {
@@ -28,31 +27,9 @@ exports.UsageCollection = class {
 
         return eventName != ""
     }
-
-    // If tracking is currently enabled, ensure we explain to the user how they can
-    // turn it off if they wish to do so.
-    explain() {
-        if (!this.enabled) return;
-        if (this.disableImporterUsageData == true) return;
-
-        const explanation = [
-            "You are currently sending anonymous usage data to the prototype kit team.",
-            "In addition to this, anonymous usage data is also being sent to the authors",
-            "of the Data Upload Design Kit.",
-            "Should you wish to disable this you can do so by adding",
-            "",
-            "    disableImporterUsageData: true",
-            "",
-            "to the usage-data-config.json file in the prototype's directory.",
-            "", "",
-
-        ]
-
-        console.log(explanation.join('\n'));
-    }
 }
 
-const usageCollectionSettings = () => {
+const prototypeKitUsageCollectionSettings = () => {
     const projectDir = path.resolve(
         process.env.KIT_PROJECT_DIR || process.cwd(),
     );

--- a/lib/importer/src/usage.js
+++ b/lib/importer/src/usage.js
@@ -20,11 +20,16 @@ exports.UsageCollection = class {
         this.enabled = settings.ddukCollectUsageData
     }
 
+    setPermission(perm) {
+        updateDDUKPermission(perm)
+        this.enabled = perm
+    }
+
     recordEvent(eventName) {
         if (!this.enabled) return false;
 
         //TODO: Actually record the usage against eventName
-
+        console.log("EVENT: " + eventName)
         return eventName != ""
     }
 }
@@ -36,4 +41,17 @@ const prototypeKitUsageCollectionSettings = () => {
     const usage_config = path.join(projectDir, "usage-data-config.json")
     const data = fs.readFileSync(usage_config);
     return JSON.parse(data)
+}
+
+const updateDDUKPermission = (ddukPermission) => {
+    const projectDir = path.resolve(
+        process.env.KIT_PROJECT_DIR || process.cwd(),
+    );
+    const usage_config = path.join(projectDir, "usage-data-config.json")
+    const data = fs.readFileSync(usage_config);
+
+    const obj = JSON.parse(data)
+    obj.ddukCollectUsageData = ddukPermission
+
+    fs.writeFileSync(usage_config, JSON.stringify(obj))
 }

--- a/lib/importer/src/usage.test.js
+++ b/lib/importer/src/usage.test.js
@@ -1,0 +1,58 @@
+const mock_files = require('mock-fs');
+var usage = require('./usage');
+
+
+describe("Usage recording tests", () => {
+    beforeEach(() => {
+        process.env.KIT_PROJECT_DIR = "./empty"
+    });
+
+    afterEach(() => {
+        mock_files.restore();
+    });
+
+    test('not enabled', () => {
+        mock_files({
+            './empty/usage-data-config.json': JSON.stringify({ collectUsageData: false })
+        })
+
+        const u = new usage.UsageCollection()
+        expect(u).not.toBeNull()
+        expect(u.recordEvent("test")).toBe(false)
+    });
+
+    test('enabled', () => {
+        mock_files({
+            './empty/usage-data-config.json': JSON.stringify({ collectUsageData: true, clientId: "1" })
+        })
+
+        const u = new usage.UsageCollection()
+        expect(u).not.toBeNull()
+
+        expect(u.recordEvent("test")).toBe(true)
+        expect(u.clientId).toBe("1")
+    });
+
+    test('enabled and importer not disabled explicitly', () => {
+        mock_files({
+            './empty/usage-data-config.json': JSON.stringify({ collectUsageData: true, clientId: "1", disableImporterUsageData: false })
+        })
+
+        const u = new usage.UsageCollection()
+        expect(u).not.toBeNull()
+
+        expect(u.recordEvent("test")).toBe(true)
+        expect(u.clientId).toBe("1")
+    });
+
+    test('enabled but importer disabled', () => {
+        mock_files({
+            './empty/usage-data-config.json': JSON.stringify({ collectUsageData: true, clientId: "1", disableImporterUsageData: true })
+        })
+
+        const u = new usage.UsageCollection()
+        expect(u).not.toBeNull()
+
+        expect(u.recordEvent("test")).toBe(false)
+    });
+});

--- a/lib/importer/src/usage.test.js
+++ b/lib/importer/src/usage.test.js
@@ -11,7 +11,7 @@ describe("Usage recording tests", () => {
         mock_files.restore();
     });
 
-    test('not enabled', () => {
+    test('not present', () => {
         mock_files({
             './empty/usage-data-config.json': JSON.stringify({ collectUsageData: false })
         })
@@ -21,38 +21,39 @@ describe("Usage recording tests", () => {
         expect(u.recordEvent("test")).toBe(false)
     });
 
-    test('enabled', () => {
+
+    test('not enabled', () => {
         mock_files({
-            './empty/usage-data-config.json': JSON.stringify({ collectUsageData: true, clientId: "1" })
+            './empty/usage-data-config.json': JSON.stringify({ collectUsageData: false, ddukCollectUsageData: false })
         })
 
         const u = new usage.UsageCollection()
         expect(u).not.toBeNull()
-
-        expect(u.recordEvent("test")).toBe(true)
-        expect(u.clientId).toBe("1")
-    });
-
-    test('enabled and importer not disabled explicitly', () => {
-        mock_files({
-            './empty/usage-data-config.json': JSON.stringify({ collectUsageData: true, clientId: "1", disableImporterUsageData: false })
-        })
-
-        const u = new usage.UsageCollection()
-        expect(u).not.toBeNull()
-
-        expect(u.recordEvent("test")).toBe(true)
-        expect(u.clientId).toBe("1")
-    });
-
-    test('enabled but importer disabled', () => {
-        mock_files({
-            './empty/usage-data-config.json': JSON.stringify({ collectUsageData: true, clientId: "1", disableImporterUsageData: true })
-        })
-
-        const u = new usage.UsageCollection()
-        expect(u).not.toBeNull()
-
         expect(u.recordEvent("test")).toBe(false)
     });
+
+    test('enabled with prototype kit enabled', () => {
+        mock_files({
+            './empty/usage-data-config.json': JSON.stringify({ collectUsageData: true, ddukCollectUsageData: true, clientId: "1" })
+        })
+
+        const u = new usage.UsageCollection()
+        expect(u).not.toBeNull()
+
+        expect(u.recordEvent("test")).toBe(true)
+        expect(u.clientId).toBe("1")
+    });
+
+    test('enabled with prototype kit disabled', () => {
+        mock_files({
+            './empty/usage-data-config.json': JSON.stringify({ collectUsageData: false, ddukCollectUsageData: true, clientId: "1" })
+        })
+
+        const u = new usage.UsageCollection()
+        expect(u).not.toBeNull()
+
+        expect(u.recordEvent("test")).toBe(true)
+        expect(u.clientId).toBe("1")
+    });
+
 });

--- a/lib/importer/views/plugin_config.html
+++ b/lib/importer/views/plugin_config.html
@@ -93,7 +93,40 @@
       </div>
 
     </div>
-  </div>
+      <form action="config" method="post">
+
+    <div class="govuk-grid-column-full govuk-!-padding-top-6" >
+        <h2 class="govuk-heading-l"></h2>
+
+<div class="govuk-form-group">
+  <fieldset class="govuk-fieldset" aria-describedby="waste-hint">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+      <h1 class="govuk-fieldset__heading">
+        Report usage data
+      </h1>
+    </legend>
+
+    <p class="govuk-body">
+      Allow Register Dynamics to collect usage data on your use of the Data Upload Design Kit.
+      When enabled, the following events will be reported with no further data:
+      <ul class="govuk-list govuk-list--bullet">
+       <li>The Plugin was initialised</li>
+       <li>The Plugin was configured</li>
+      </ul>
+    </p>
+
+    <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+      <div class="govuk-checkboxes__item">
+        <input class="govuk-checkboxes__input" id="collectData" name="collectData" type="checkbox" value="true" {% if collectUsageData == true %}checked{% endif %}>
+        <label class="govuk-label govuk-checkboxes__label" for="collectData">
+          Allow collection of usage data
+        </label>
+      </div>
+    </div>
+  </fieldset>
+</div>
+    </div>
+
 
     <div class="govuk-grid-column-full govuk-!-padding-top-6" >
       <h2 class="govuk-heading-l">Save changes</h2>
@@ -105,7 +138,6 @@
         use the new settings.
       </p>
 
-      <form action="config" method="post">
         <div class="govuk-form-group {% if error %}govuk-form-group--error{% endif %}">
           {% if error %}
           <p id="path_err" class="govuk-error-message">

--- a/lib/importer/views/plugin_config.html
+++ b/lib/importer/views/plugin_config.html
@@ -99,7 +99,7 @@
         <h2 class="govuk-heading-l"></h2>
 
 <div class="govuk-form-group">
-  <fieldset class="govuk-fieldset" aria-describedby="waste-hint">
+  <fieldset class="govuk-fieldset">
     <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
       <h1 class="govuk-fieldset__heading">
         Report usage data
@@ -116,14 +116,23 @@
       </ul>
     </p>
 
-    <div class="govuk-checkboxes" data-module="govuk-checkboxes">
-      <div class="govuk-checkboxes__item">
-        <input class="govuk-checkboxes__input" id="collectData" name="collectData" type="checkbox" value="true" {% if collectUsageData == true %}checked{% endif %}>
-        <label class="govuk-label govuk-checkboxes__label" for="collectData">
-          Allow collection of usage data
-        </label>
+    <p class="govuk-body">
+      <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+        <div class="govuk-checkboxes__item">
+          <input class="govuk-checkboxes__input" id="collectData" name="collectData" type="checkbox" value="true" {% if collectUsageData == true %}checked{% endif %}>
+          <label class="govuk-label govuk-checkboxes__label" for="collectData">
+            Allow collection of usage data
+          </label>
+        </div>
       </div>
-    </div>
+    </p>
+
+
+    <p class="govuk-body">
+      If you don't want usage data to be collected, please consider
+      <a href="https://github.com/register-dynamics/data-import/discussions">dropping a note to us on Github</a>
+      to let us know how you're using the Kit. Thanks!
+    </p>
   </fieldset>
 </div>
     </div>

--- a/lib/importer/views/plugin_config.html
+++ b/lib/importer/views/plugin_config.html
@@ -108,7 +108,8 @@
 
     <p class="govuk-body">
       Allow Register Dynamics to collect usage data on your use of the Data Upload Design Kit.
-      When enabled, the following events will be reported with no further data:
+      When enabled, the Data Upload Design Kit will only report the following events with an
+      anonymous identifier specific to this prototype:
       <ul class="govuk-list govuk-list--bullet">
        <li>The Plugin was initialised</li>
        <li>The Plugin was configured</li>


### PR DESCRIPTION
Adds a new option to the configuration page, to allow users to opt-in to usage data collection, which looks like:

![Plugin_Configuration_-_Upload_monthly_pension_return](https://github.com/user-attachments/assets/17bdb10c-3300-4bc9-aecc-3cd013f3ae12)

Not 100% sure of the wording, but the functionality works as advertised, adding a new option to the `usage-data-config.json` file. 

Note this does not actually collect any data at present, but simply prints the event name out to the console.