### PR TITLE
Auto-populate field names in the mapper if they match

### DIFF
--- a/lib/importer/nunjucks/importer/macros/field_mapper.njk
+++ b/lib/importer/nunjucks/importer/macros/field_mapper.njk
@@ -16,6 +16,7 @@
 #}
 {% macro importerFieldMapper(data, caption='', columnTitle='Column', examplesTitle='Example values', fieldsTitle='Fields') %}
     {% set fields = data['importer.session']['fields'] %}
+    {% set mapping = data['importer.session']['mapping'] %}
     {% set headings = importerGetHeaders(data) %}
     {% set headingError = headings.error %}
     {% set error = importerError(data) %}
@@ -57,6 +58,7 @@
     </tr>
   </thead>
   <tbody class="govuk-table__body">
+    {% set mappingsLen = mapping | length %}
     {% for h in headings.data %}
       {% set hIndex = loop.index0 %}
       {% set currentValue = importerErrorMappingData(error, hIndex) %}
@@ -68,7 +70,9 @@
          <select class="govuk-select" style="float: right;" name="{{h.index}}">
                 <option name=""></option>
                 {% for field in fields %}
-                    <option value="{{field.name}}" {% if field.name == currentValue %}selected{% endif%}>{{field.name}}</option>
+                    <option value="{{field.name}}" {% if field.name == currentValue or (mappingsLen == 0 and field.name == h.name) %}selected{% endif %}>
+                      {{field.name}}
+                    </option>
                 {% endfor %}
             </select>
       </td>


### PR DESCRIPTION
If the name of a column in the user-submitted data matches the name of a configured field, we now automatically select the field in the column's mapping drop-down.

We only do this if the user previously hasn't submitted a mapping. This is so that any fields they left blank will continue to be blank and won't be overriden by the default if they come back to the mapping page to correct an error.