### PR TITLE
Document the current release process

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ To release a new version of the Data Upload Design Kit, resulting in the package
 Update the version field in the [package.json](./lib/importer/package.json).
 The major/minor/patch version should be updated as appropriate.  You should submit this change as a pull request.
 
-Make sure you also run the demo prototype so that it discovers the new local version, otherwise the demo will update in the next PR and you may end up with several developers trying to submit the same change.
+Make sure you also run the demo prototype so that it discovers the new local version, otherwise the demo will update in the next PR and you may end up with several developers trying to submit the same change. You can do this using `npm i` to update the prototype's dependency on the package.
 
 ### Merge into main
 

--- a/README.md
+++ b/README.md
@@ -39,3 +39,29 @@ $ npm run dev
 ```
 
 Changes to the prototype files in `prototypes/[abc]` and `lib/importer` will force the prototype to reload.
+
+## Release Process
+
+To release a new version of the Data Upload Design Kit, resulting in the package being available at <https://www.npmjs.com/package/@register-dynamics/importer>,  you should follow these steps:
+
+### Update the package version
+
+Update the version field in the [package.json](./lib/importer/package.json).
+The major/minor/patch version should be updated as appropriate.  You should submit this change as a pull request.
+
+Make sure you also run the demo prototype so that it discovers the new local version, otherwise the demo will update in the next PR and you may end up with several developers trying to submit the same change.
+
+### Merge into main
+
+Following the usual process, and once approval is obtained for the change, merge the pull request into the `main` branch. This will result in the usual CI steps and followed by a deployment of the demo prototype.
+
+### Create a new github release
+
+Create a new github release, making sure to:
+
+* Create a new tag, beginning with v matching the current version, e.g. v1.2.0
+* Ensure the desciption contains a high level overview of the changes and a changelog based on the commits in this release (github will help with this stage).
+* Publish the release.
+
+The final stage of this process will result in github actions publishing this package to npm.
+

--- a/prototypes/basic/package-lock.json
+++ b/prototypes/basic/package-lock.json
@@ -18,7 +18,7 @@
     },
     "../../lib/importer": {
       "name": "@register-dynamics/importer",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {


### PR DESCRIPTION
Explains how to perform a new release of the package, from updating the version to performing a github release.

The change to the demo prototype's package-lock is explained in this PR at https://github.com/register-dynamics/data-import/compare/describe-release-process?expand=1#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R52 - it is the result of not updating it in the last releasse.