### PR TITLE
Record usage events where permission granted

### DIFF
--- a/lib/importer/src/index.js
+++ b/lib/importer/src/index.js
@@ -40,7 +40,7 @@ exports.Initialise = (config, router, prototypeKit) => {
   const usageRecorder = new usage.UsageCollection(plugin_config)
 
   // Record initialisation of the plugin
-  usageRecorder.recordEvent("Plugin initialised")
+  usageRecorder.recordEvent("initialised")
 
   //--------------------------------------------------------------------
   // To be able to add a local views folder, we need to update the
@@ -346,7 +346,7 @@ exports.Initialise = (config, router, prototypeKit) => {
       (request, response) => {
 
         // Record initialisation of the plugin
-        usageRecorder.recordEvent("Plugin configured")
+        usageRecorder.recordEvent("configured")
 
 
         const pc = {

--- a/lib/importer/src/usage.js
+++ b/lib/importer/src/usage.js
@@ -11,7 +11,8 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
-
+const httplib = require('https');
+const { URL } = require('url');
 
 exports.UsageCollection = class {
     constructor() {
@@ -21,18 +22,95 @@ exports.UsageCollection = class {
     }
 
     setPermission(perm) {
-        updateDUDKPermission(perm)
+        this.updateDUDKPermission(perm)
         this.enabled = perm
     }
+
+    updateDUDKPermission(dudkPermission) {
+        const projectDir = path.resolve(projectDirectory() || process.cwd());
+        const usage_config = path.join(projectDir, "usage-data-config.json")
+
+        // We are running in production mode, usage tracking now enabled here.
+        if (!fs.existsSync(usage_config)) {
+            return
+        }
+
+        const data = fs.readFileSync(usage_config);
+        const obj = JSON.parse(data)
+        obj.dudkCollectUsageData = dudkPermission
+
+        // If no clientid because the user said no to the prototype kit,
+        // then we will create and save one.
+        if (!('clientId' in obj)) {
+            obj.clientId = crypto.randomUUID();
+        }
+
+
+        fs.writeFileSync(usage_config, JSON.stringify(obj))
+    }
+
+
 
     recordEvent(eventName) {
         if (!this.enabled) return false;
 
-        //TODO: Actually record the usage against eventName
-        console.log("EVENT: " + eventName)
+        // Make the request in a block that will allow us to return
+        // immediately whilst the event is recorded
+        (async () => {
+            const response = await this.create_event_request(eventName, this.clientId);
+            if (response.error) {
+                console.log("Failed to record event");
+            }
+        })();
+
 
         return eventName != ""
     }
+
+    // Create a promise that will make our HTTP request for us, ensuring
+    // that it will swallow any errors so that we don't interupt the operation
+    // of the prototype.
+    async create_event_request(eventName, clientID) {
+        // Creates a path that acts as our event record. For now this is
+        // just a simple path with no extra payload.
+        const url = new URL(`https://union.register-dynamics.co.uk/dudk-metrics/${clientID}/${eventName}`);
+
+        return new Promise((resolve) => {
+            try {
+
+                const options = {
+                    method: "GET",
+                    hostname: url.hostname,
+                    path: url.pathname + url.search,
+                    port: 443,
+                };
+
+                const req = httplib.request(options, (res) => {
+                    res.on('end', () => {
+                        resolve({
+                            statusCode: res.statusCode,
+                            headers: res.headers,
+                        });
+                    });
+                });
+
+                req.on('error', (err) => {
+                    resolve({
+                        error: true,
+                        message: err.message,
+                    });
+                });
+
+                req.end();
+            } catch (err) {
+                resolve({
+                    error: true,
+                    message: err.message,
+                });
+            }
+        });
+    }
+
 }
 
 // KIT_PROJECT_DIR contains the app folder, and so if it exists in prod or dev
@@ -44,8 +122,6 @@ const projectDirectory = () => {
 }
 
 const prototypeKitUsageCollectionSettings = () => {
-
-
     const projectDir = path.resolve(projectDirectory() || process.cwd());
     const usage_config = path.join(projectDir, "usage-data-config.json")
     if (!fs.existsSync(usage_config)) {
@@ -56,18 +132,4 @@ const prototypeKitUsageCollectionSettings = () => {
     return JSON.parse(data)
 }
 
-const updateDUDKPermission = (dudkPermission) => {
-    const projectDir = path.resolve(projectDirectory() || process.cwd());
-    const usage_config = path.join(projectDir, "usage-data-config.json")
 
-    // We are running in production mode, usage tracking now enabled here.
-    if (!fs.existsSync(usage_config)) {
-        return
-    }
-
-    const data = fs.readFileSync(usage_config);
-    const obj = JSON.parse(data)
-    obj.dudkCollectUsageData = dudkPermission
-
-    fs.writeFileSync(usage_config, JSON.stringify(obj))
-}


### PR DESCRIPTION
Where the user has possibly granted permission for us to record usage data, we will now make a HTTPS request to an RD server, containing only the client's uuid (generated by either us or the prototype kit depending on permissions) and the name of the event. If the recording fails, then we will not interupt the usage of the prototype at all, instead just recording the failure in the user's terminal.