### PR TITLE
Ignore case when verifying client id UUIDs

### DIFF
--- a/tools/usage-collector/dudk_stats/helpers.py
+++ b/tools/usage-collector/dudk_stats/helpers.py
@@ -52,7 +52,8 @@ class MetricRow:
 ROW_RE = re.compile(r"\[(.*?)\]\s+(\S+)\s+(\d{3})")
 EVENT_RE = re.compile(r"\/dudk-metrics/(.*)/(.*)")
 UUID_RE = re.compile(
-    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}$"
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}$",
+    re.IGNORECASE,
 )
 
 


### PR DESCRIPTION
Currently the regex verifying that the client id is a regex is case sensitive, but regex can be uppercase too, and so this change allows any case.