### PR TITLE
Correctly show text from warnings

### DIFF
--- a/lib/importer/templates/review.html
+++ b/lib/importer/templates/review.html
@@ -80,7 +80,13 @@
         <p class="govuk-body">
             <ul class="govuk-list govuk-list--bullet">
                 {% for idx, warning in results.warnings %}
-                <li>Row {{ idx }}: {{ warning }}</li>
+                    {% for e in warning %}
+                    <tr class="govuk-table__row">
+                        <td class="govuk-table__cell"> {{idx}} </td>
+                        <td class="govuk-table__cell">  {{e.field}} </td>
+                        <td class="govuk-table__cell"> {{e.message}} </td>
+                    </tr>
+                    {% endfor %}
                 {% endfor %}
               </ul>
         </p>

--- a/prototypes/basic/app/views/review.html
+++ b/prototypes/basic/app/views/review.html
@@ -80,7 +80,13 @@
         <p class="govuk-body">
             <ul class="govuk-list govuk-list--bullet">
                 {% for idx, warning in results.warnings %}
-                <li>Row {{ idx }}: {{ warning }}</li>
+                    {% for e in warning %}
+                    <tr class="govuk-table__row">
+                        <td class="govuk-table__cell"> {{idx}} </td>
+                        <td class="govuk-table__cell">  {{e.field}} </td>
+                        <td class="govuk-table__cell"> {{e.message}} </td>
+                    </tr>
+                    {% endfor %}
                 {% endfor %}
               </ul>
         </p>


### PR DESCRIPTION
The current behaviour doesn't expect warnings to be an object, and so just shows '[object Object]' instead of the warning. This commit fixes it so that warnings are shown in a table like errors.