### PR TITLE
Display column index in table THEAD

### DIFF
--- a/lib/importer/assets/js/selectable_table.js
+++ b/lib/importer/assets/js/selectable_table.js
@@ -564,6 +564,9 @@ window.addEventListener("load", function() {
       }
 
       static fromElement(element) {
+        if (element.parentElement.tagName == "THEAD"){
+          return NilSelection;
+        }
         if (element.nodeName == "TABLE") {
           var topLeft = element.rows[0].cells[0];
           var lastRow = element.rows[element.rows.length - 1];
@@ -698,10 +701,12 @@ window.addEventListener("load", function() {
         selection.focus.node.scrollIntoViewIfNeeded(false);
 
         // If we have HTML elements defined on the page (with specific names) then they will be used
-        // to store the top left row/column and bottom right row/column.
-        if (tlRowTarget) { tlRowTarget.value = selection.startCell.row; }
+        // to store the top left row/column and bottom right row/column. 
+          // We reduce the row index by one to handle the table chrome 
+          // which should not be included in the selection.
+        if (tlRowTarget) { tlRowTarget.value = selection.startCell.row - 1; }
         if (tlColTarget) { tlColTarget.value = selection.startCell.col; }
-        if (brRowTarget) { brRowTarget.value = selection.endCell.row; }
+        if (brRowTarget) { brRowTarget.value = selection.endCell.row - 1; }
         if (brColTarget) { brColTarget.value = selection.endCell.col; }
       }
 

--- a/lib/importer/nunjucks/importer/macros/range_selector.njk
+++ b/lib/importer/nunjucks/importer/macros/range_selector.njk
@@ -8,17 +8,28 @@
     <input type="hidden" name="importer:selection:BRCol" id="importer:selection:BRCol"/>
 </div>
 
+    {% set row_length = rows[0].length %}
+
     <div class="rd-range-selector">
       <table class="selectable govuk-body"
              data-persist-selection="true"
              role="grid" aria-multiselectable="true"
              {% if caption %}
              aria-labelledby="tablecaption"
-             {% endif %}  
+             {% endif %}
       >
           {% if caption %}
           <caption id="tablecaption" class="govuk-table__caption govuk-table__caption--m">{{caption}}</caption>
           {% endif %}
+
+          <thead>
+            <tr>
+              {% for i in range(0, row_length) -%}
+                <th>{{ i | encode_header }}</th>
+              {% endfor %}
+            </tr>
+          </thead>
+
           <tbody role="rowgroup">
               {% for row in rows %}
               <tr role="row">

--- a/lib/importer/nunjucks/importer/macros/sheet_selector.njk
+++ b/lib/importer/nunjucks/importer/macros/sheet_selector.njk
@@ -60,7 +60,7 @@
             </div>
           {% else %}
             {% set caption = importerGetTableCaption(data, "First", 10, sheet.name) %}
-            {{ importerTableView(sheet.data, caption=caption, hideHeader=true) }}
+            {{ importerTableView(sheet.data, caption=caption) }}
           {% endif %}
         </div>
       {% endfor %}

--- a/lib/importer/nunjucks/importer/macros/table_view.njk
+++ b/lib/importer/nunjucks/importer/macros/table_view.njk
@@ -1,7 +1,8 @@
 
-{% macro importerTableView(data, caption=false, hideHeader=false ) %}
+{% macro importerTableView(data, caption=false, headers=[] ) %}
     {% set headers = data.headers %}
     {% set rows = data.rows %}
+    {% set row_length = rows[0].length %}
     {% set moreRowsAvailable = data.extraRecordCount > 0 %}
     {% set moreRowsCount = data.extraRecordCount %}
 
@@ -9,7 +10,7 @@
         {% if caption %}
           <caption class="govuk-table__caption govuk-table__caption--m">{{caption}}</caption>
         {% endif %}
-        {% if not hideHeader %}
+        {% if headers %}
         <thead>
             <tr>
             {% for h in headers %}
@@ -17,6 +18,14 @@
             {% endfor %}
             </tr>
         </thead>
+        {% else %}
+          <thead>
+              <tr>
+                {% for i in range(0, row_length) -%}
+                  <th>{{ i | encode_header }}</th>
+                {% endfor %}
+              </tr>
+          </thead>
         {% endif %}
         <tbody>
             {% for row in rows %}

--- a/lib/importer/src/filters.js
+++ b/lib/importer/src/filters.js
@@ -1,4 +1,4 @@
-
+const base26 = require('./base26')
 
 const currency = (content) => {
     const num = parseInt(content)
@@ -20,4 +20,10 @@ const pluralize = (count, singular, plural) => {
     return plural
 }
 
-module.exports = { currency, slugify, pluralize }
+const encode_header = (idx) => {
+    // Add 1 as the idx will be 0-based and we want
+    // 1-based for the display.
+    return base26.toBase26(idx + 1)
+}
+
+module.exports = { currency, slugify, pluralize, encode_header }


### PR DESCRIPTION
Currently when there is no header name specified, the first row in the table is not shown. To allow users to relate this to the data they can see in their source file, we instead show the column index in base26 (A, B, C ... AA, AB, AC ... etc).

Currently the selectable_table will include this new row in the calculation for the selection, and so we need to make sure we account for it when saving selections.