### PR TITLE
Enable header row display in tables

### DIFF
--- a/lib/importer/assets/js/selectable_table.js
+++ b/lib/importer/assets/js/selectable_table.js
@@ -697,11 +697,15 @@ window.addEventListener("load", function() {
         for (var cell of selection.rightCells) { cell.node.classList.add(CellSelectedRightClassName); }
         selection.focus.node.scrollIntoViewIfNeeded(false);
 
+        const headerRowCellCount = document.querySelectorAll('th[role="col"]').length
+        const headerRowOffset = headerRowCellCount > 0 ? 1 : 0;
+
+
         // If we have HTML elements defined on the page (with specific names) then they will be used
         // to store the top left row/column and bottom right row/column.
-        if (tlRowTarget) { tlRowTarget.value = selection.startCell.row; }
+        if (tlRowTarget) { tlRowTarget.value = selection.startCell.row - headerRowOffset; }
         if (tlColTarget) { tlColTarget.value = selection.startCell.col; }
-        if (brRowTarget) { brRowTarget.value = selection.endCell.row; }
+        if (brRowTarget) { brRowTarget.value = selection.endCell.row - headerRowOffset; }
         if (brColTarget) { brColTarget.value = selection.endCell.col; }
       }
 

--- a/lib/importer/assets/js/selectable_table.js
+++ b/lib/importer/assets/js/selectable_table.js
@@ -697,7 +697,7 @@ window.addEventListener("load", function() {
         for (var cell of selection.rightCells) { cell.node.classList.add(CellSelectedRightClassName); }
         selection.focus.node.scrollIntoViewIfNeeded(false);
 
-        const headerRowCellCount = document.querySelectorAll('th[role="col"]').length
+        const headerRowCellCount = table.querySelectorAll('th[scope="col"]').length
         const headerRowOffset = headerRowCellCount > 0 ? 1 : 0;
 
 

--- a/lib/importer/assets/js/selectable_table.js
+++ b/lib/importer/assets/js/selectable_table.js
@@ -698,7 +698,8 @@ window.addEventListener("load", function() {
         selection.focus.node.scrollIntoViewIfNeeded(false);
 
         const headerRowCellCount = table.querySelectorAll('th[scope="col"]').length
-        const headerRowOffset = headerRowCellCount > 0 ? 1 : 0;
+        const headerRowCount = table.querySelectorAll('thead tr').length
+        const headerRowOffset = headerRowCellCount > 0 ? headerRowCount  : 0;
 
 
         // If we have HTML elements defined on the page (with specific names) then they will be used

--- a/lib/importer/nunjucks/importer/macros/footer_selector.njk
+++ b/lib/importer/nunjucks/importer/macros/footer_selector.njk
@@ -5,5 +5,7 @@
     {% set rows = importerGetTrailingRows(data, count) %}
     {% set caption = importerGetTableCaption(data, "Last", count) %}
 
-    {{ importerRangeSelector(rows, caption) }}
+    {% set tableHeaders = importerHeaderRowDisplay(data, "source") %}
+
+    {{ importerRangeSelector(rows, caption, tableHeaders) }}
 {% endmacro %}

--- a/lib/importer/nunjucks/importer/macros/header_selector.njk
+++ b/lib/importer/nunjucks/importer/macros/header_selector.njk
@@ -4,6 +4,7 @@
 {% macro importerHeaderSelector(data, start, count=10) %}
     {% set rows = importerGetRows(data, start, count) %}
     {% set caption = importerGetTableCaption(data, "First", count) %}
+    {% set tableHeaders =  importerHeaderRowDisplay(data, "index") %}
 
-    {{ importerRangeSelector(rows, caption) }}
+    {{ importerRangeSelector(rows, caption, tableHeaders) }}
 {% endmacro %}

--- a/lib/importer/nunjucks/importer/macros/range_selector.njk
+++ b/lib/importer/nunjucks/importer/macros/range_selector.njk
@@ -1,5 +1,5 @@
 
-{% macro importerRangeSelector(rows, caption) %}
+{% macro importerRangeSelector(rows, caption, tableHeaders=[]) %}
 
 <div>
     <input type="hidden" name="importer:selection:TLRow" id="importer:selection:TLRow"/>
@@ -14,10 +14,20 @@
              role="grid" aria-multiselectable="true"
              {% if caption %}
              aria-labelledby="tablecaption"
-             {% endif %}  
+             {% endif %}
       >
           {% if caption %}
           <caption id="tablecaption" class="govuk-table__caption govuk-table__caption--m">{{caption}}</caption>
+          {% endif %}
+
+          {% if tableHeaders %}
+           <thead>
+            <tr>
+              {% for h in tableHeaders %}
+              <th role="col">{{ h }}</th>
+              {% endfor %}
+            </tr>
+          </thead>
           {% endif %}
           <tbody role="rowgroup">
               {% for row in rows %}

--- a/lib/importer/nunjucks/importer/macros/range_selector.njk
+++ b/lib/importer/nunjucks/importer/macros/range_selector.njk
@@ -24,7 +24,7 @@
            <thead>
             <tr>
               {% for h in tableHeaders %}
-              <th role="col">{{ h }}</th>
+              <th scope="col">{{ h }}</th>
               {% endfor %}
             </tr>
           </thead>

--- a/lib/importer/nunjucks/importer/macros/sheet_selector.njk
+++ b/lib/importer/nunjucks/importer/macros/sheet_selector.njk
@@ -60,7 +60,7 @@
             </div>
           {% else %}
             {% set caption = importerGetTableCaption(data, "First", 10, sheet.name) %}
-            {{ importerTableView(sheet.data, caption=caption, hideHeader=true) }}
+            {{ importerTableView(data, sheet.data, caption=caption, headerMode="none") }}
           {% endif %}
         </div>
       {% endfor %}

--- a/lib/importer/nunjucks/importer/macros/table_view.njk
+++ b/lib/importer/nunjucks/importer/macros/table_view.njk
@@ -1,18 +1,21 @@
 
-{% macro importerTableView(data, caption=false, hideHeader=false ) %}
+{% macro importerTableView(session, data, caption=false, headerMode="none" ) %}
     {% set headers = data.headers %}
     {% set rows = data.rows %}
     {% set moreRowsAvailable = data.extraRecordCount > 0 %}
     {% set moreRowsCount = data.extraRecordCount %}
 
+    {% set tableHeaders = importerHeaderRowDisplay(session, headerMode) %}
+
     <table class="selectable govuk-body" data-persist-selection="true">
         {% if caption %}
           <caption class="govuk-table__caption govuk-table__caption--m">{{caption}}</caption>
         {% endif %}
-        {% if not hideHeader %}
+        {% if tableHeaders %}
         <thead>
+
             <tr>
-            {% for h in headers %}
+            {% for h in tableHeaders %}
                 <th>{{h}}</th>
             {% endfor %}
             </tr>

--- a/lib/importer/src/backend.js
+++ b/lib/importer/src/backend.js
@@ -551,7 +551,7 @@ exports.SessionPerformMappingJob = (sid, range, mapping, includeErrorRow = false
         const result = attrType(inputVal);
 
         result.warnings.forEach((text) => {
-          rowWarnings.push({ row: rowIdx, field: attr, message: text});
+          rowWarnings.push({ row: rowIdx, field: attr, message: text });
         });
 
         if (result.valid) {
@@ -576,7 +576,7 @@ exports.SessionPerformMappingJob = (sid, range, mapping, includeErrorRow = false
         records.push(mappedRecord);
       }
     } else {
-      rowWarnings.push({row: rowIdx, message: "Row is empty"})
+      rowWarnings.push({ row: rowIdx, message: "Row is empty" })
     }
 
     if (rowWarnings.length > 0) {

--- a/lib/importer/src/functions.js
+++ b/lib/importer/src/functions.js
@@ -1,5 +1,6 @@
 
 const sheets_lib = require("./sheets.js");
+const session_lib = require("./session.js");
 
 const IMPORTER_SESSION_KEY = "importer.session";
 const IMPORTER_ERROR_KEY = "importer.error";
@@ -162,6 +163,11 @@ const importerMappedData = (data) => {
     };
 }
 
+const importerHeaderRowDisplay = (data, mode) => {
+    const session = data[IMPORTER_SESSION_KEY];
+    return session_lib.HeaderRowDisplay(session, mode)
+}
+
 //--------------------------------------------------------------------
 // Helper functions that can be used on the review page to show
 // information about the data that has been mapped.
@@ -235,6 +241,7 @@ module.exports = {
     importerGetTrailingRows,
     importerGetTableCaption,
     importerMappedData,
+    importerHeaderRowDisplay,
     data_sum,
     data_avg
 }

--- a/lib/importer/src/index.js
+++ b/lib/importer/src/index.js
@@ -532,7 +532,7 @@ const getIntOrDefault = (key, dflt = 0) => {
 // then we will return no range.
 const getSelectionFromRequest = (request, session, optional = false) => {
   let defaultVal = optional ? -1 : 0;
-  let defaultMaxCol = optional ? -1 : sheets_lib.GetTotalColumns(session);
+  let defaultMaxCol = optional ? -1 : (sheets_lib.GetTotalColumns(session) - 1);
 
   let tlRow = getIntOrDefault(
     request.body["importer:selection:TLRow"],

--- a/lib/importer/src/index.js
+++ b/lib/importer/src/index.js
@@ -241,6 +241,7 @@ exports.Initialise = (config, router, prototypeKit) => {
 
       // Ensure the session is persisted. Currently in session, eventually another way
       request.session.data[IMPORTER_SESSION_KEY] = session;
+
       redirectOnwards(request, response);
     },
   );

--- a/lib/importer/src/session.js
+++ b/lib/importer/src/session.js
@@ -174,7 +174,8 @@ exports.HeaderRowDisplay = (session, displayMode) => {
 // Calculate the range, either from the currently selected columns, or from the number
 // of items in a row (making the assumption that they're even).
 const calculateHeaderRange = (session) => {
-  if (Object.prototype.hasOwnProperty.call(session.headerRange, "start") &&
+  if (Object.prototype.hasOwnProperty.call(session, "headerRange") &&
+    Object.prototype.hasOwnProperty.call(session.headerRange, "start") &&
     Object.prototype.hasOwnProperty.call(session.headerRange, "end")) {
     return [session.headerRange.start.column, session.headerRange.end.column]
   }

--- a/lib/importer/src/session.js
+++ b/lib/importer/src/session.js
@@ -84,7 +84,8 @@ exports.HeaderRowDisplay = (session, displayMode) => {
 
   // User has selected 'none' mode, which means we don't return any headers as
   // the user does not want to show them. No pre-requisites.
-  const noneMode = (range) => {
+  // eslint-disable-next-line no-unused-vars
+  const noneMode = (_range) => {
     return null
   }
 
@@ -112,7 +113,8 @@ exports.HeaderRowDisplay = (session, displayMode) => {
       return null
     }
 
-    if (!session.headerRange.hasOwnProperty("start") || !session.headerRange.hasOwnProperty("end")) {
+    if (!Object.prototype.hasOwnProperty.call(session.headerRange, "start") ||
+      !Object.prototype.hasOwnProperty.call(session.headerRange, "end")) {
       console.warn("HeaderRowDisplay: No header range available for source headers")
       return null
     }
@@ -130,7 +132,8 @@ exports.HeaderRowDisplay = (session, displayMode) => {
   // Use the header values from the mapped domain object, so the target column headings and the user's data
   // for that column.
   // Requires a selected sheet and a mapping
-  const targetMode = (range) => {
+  // eslint-disable-next-line no-unused-vars
+  const targetMode = (_range) => {
     if (!session.sheet || session.sheet == "") {
       console.warn("HeaderRowDisplay: No sheet selected so header display mode is 'none'")
       return null
@@ -171,7 +174,8 @@ exports.HeaderRowDisplay = (session, displayMode) => {
 // Calculate the range, either from the currently selected columns, or from the number
 // of items in a row (making the assumption that they're even).
 const calculateHeaderRange = (session) => {
-  if (session.headerRange.hasOwnProperty("start") && session.headerRange.hasOwnProperty("end")) {
+  if (Object.prototype.hasOwnProperty.call(session.headerRange, "start") &&
+    Object.prototype.hasOwnProperty.call(session.headerRange, "end")) {
     return [session.headerRange.start.column, session.headerRange.end.column]
   }
 

--- a/lib/importer/src/session.js
+++ b/lib/importer/src/session.js
@@ -105,10 +105,15 @@ exports.HeaderRowDisplay = (session, displayMode) => {
   }
 
   // Using the header values selected by the user, use those instead of column indices.
-  // Requires a selected sheet
+  // Requires a selected sheet and a headerRange
   const sourceMode = (range) => {
-    if (!session.sheet || session.sheet == "") {
+    if (!session.sheet || session.sheet == "" || !session.headerRange) {
       console.warn("HeaderRowDisplay: No sheet selected so header display mode is 'none'")
+      return null
+    }
+
+    if (!session.headerRange.hasOwnProperty("start") || !session.headerRange.hasOwnProperty("end")) {
+      console.warn("HeaderRowDisplay: No header range available for source headers")
       return null
     }
 
@@ -175,6 +180,7 @@ const calculateHeaderRange = (session) => {
     return null
   }
 
+  // With no specified headers, try and default to the first row.
   const r = sheets_lib.GetRows(session)
   if (r) {
     return [0, r[0].length]

--- a/lib/importer/src/session.js
+++ b/lib/importer/src/session.js
@@ -123,7 +123,7 @@ exports.HeaderRowDisplay = (session, displayMode) => {
     const headers = new Array();
 
     for (var i = range[0]; i <= range[1]; i++) {
-      headers.push(rows[i].value)
+      headers.push(rows[i]?.value ?? "")
     }
 
     return headers;

--- a/lib/importer/src/session.js
+++ b/lib/importer/src/session.js
@@ -18,6 +18,13 @@ class Session {
   }
 }
 
+class Range {
+  constructor(start, end) {
+    this.start = start
+    this.end = end
+  }
+}
+
 exports.CreateSession = (config, request) => {
   const createResponse = {
     id: "",
@@ -98,7 +105,7 @@ exports.HeaderRowDisplay = (session, displayMode) => {
     }
 
     const headers = new Array();
-    for (var i = range[0]; i <= range[1]; i++) {
+    for (var i = range.start; i <= range.end; i++) {
       headers.push(base26.toBase26(i + 1))
     }
 
@@ -122,7 +129,7 @@ exports.HeaderRowDisplay = (session, displayMode) => {
     const rows = sheets_lib.GetRows(session, session.headerRange.start.row, session.headerRange.end.row + 1)[0];
     const headers = new Array();
 
-    for (var i = range[0]; i <= range[1]; i++) {
+    for (var i = range.start; i <= range.end; i++) {
       headers.push(rows[i]?.value ?? "")
     }
 
@@ -177,7 +184,7 @@ const calculateHeaderRange = (session) => {
   if (Object.prototype.hasOwnProperty.call(session, "headerRange") &&
     Object.prototype.hasOwnProperty.call(session.headerRange, "start") &&
     Object.prototype.hasOwnProperty.call(session.headerRange, "end")) {
-    return [session.headerRange.start.column, session.headerRange.end.column]
+    return new Range(session.headerRange.start.column, session.headerRange.end.column)
   }
 
   if (!session.sheet || session.sheet == "") {
@@ -185,10 +192,11 @@ const calculateHeaderRange = (session) => {
     return null
   }
 
-  // With no specified headers, try and default to the first row.
+  // With no specified headers, try and default to the first row. This may already be set
+  // earlier in the flow, but we add this defensively.
   const r = sheets_lib.GetRows(session)
   if (r) {
-    return [0, r[0].length]
+    return new Range(0, r[0].length)
   }
 
   console.warn("HeaderRowDisplay: No rows available when determining number of columns")

--- a/lib/importer/src/session.js
+++ b/lib/importer/src/session.js
@@ -83,14 +83,15 @@ exports.HeaderRowDisplay = (session, displayMode) => {
   var mode = displayMode.toLowerCase();
 
   // User has selected 'none' mode, which means we don't return any headers as
-  // the user does not want to show them.
+  // the user does not want to show them. No pre-requisites.
   const noneMode = (range) => {
     return null
   }
 
-  // Index mode, shows the index as base26 where the values are taken from the range
+  // Index mode, shows the index as base26 where the values are taken from the range.
+  // Requires a selected sheet
   const indexMode = (range) => {
-    if (this.sheet == "") {
+    if (!session.sheet || session.sheet == "") {
       console.warn("HeaderRowDisplay: No sheet selected so header display mode is 'none'")
       return null
     }
@@ -104,7 +105,13 @@ exports.HeaderRowDisplay = (session, displayMode) => {
   }
 
   // Using the header values selected by the user, use those instead of column indices.
+  // Requires a selected sheet
   const sourceMode = (range) => {
+    if (!session.sheet || session.sheet == "") {
+      console.warn("HeaderRowDisplay: No sheet selected so header display mode is 'none'")
+      return null
+    }
+
     const rows = sheets_lib.GetRows(session, session.headerRange.start.row, session.headerRange.end.row + 1)[0];
     const headers = new Array();
 
@@ -117,23 +124,27 @@ exports.HeaderRowDisplay = (session, displayMode) => {
 
   // Use the header values from the mapped domain object, so the target column headings and the user's data
   // for that column.
+  // Requires a selected sheet and a mapping
   const targetMode = (range) => {
+    if (!session.sheet || session.sheet == "") {
+      console.warn("HeaderRowDisplay: No sheet selected so header display mode is 'none'")
+      return null
+    }
+
+    if (!session.mapping) {
+      console.warn("HeaderRowDisplay: No mapping available so header display mode is 'none'")
+      return null
+    }
+
     return noneMode;
   }
 
-  // Calculate the range, either from the currently selected columns, or from the number
-  // of items in a row (making the assumption that they're even).
-  var range = {};
-  if (session.headerRange.hasOwnProperty("start") && session.headerRange.hasOwnProperty("end")) {
-    range = [session.headerRange.start.column, session.headerRange.end.column]
-  } else {
-    const r = sheets_lib.GetRows(session)
-    if (!r) {
-      console.warn("HeaderRowDisplay: No rows available when determining number of columns")
-      return null
-    } else {
-      range = [0, r[0].length]
-    }
+  var range = calculateHeaderRange(session)
+
+  // Unless the mode is 'none' then a sheet is required to return headers for display
+  if (mode != "none" && (!session.sheet || session.sheet == "")) {
+    console.warn("HeaderRowDisplay: No sheet selected so header display mode is 'none'")
+    return null
   }
 
   switch (mode) {
@@ -150,4 +161,25 @@ exports.HeaderRowDisplay = (session, displayMode) => {
 
   // If 'none' is specified, or the value provided isn't supported...
   return noneMode(range);
+}
+
+// Calculate the range, either from the currently selected columns, or from the number
+// of items in a row (making the assumption that they're even).
+const calculateHeaderRange = (session) => {
+  if (session.headerRange.hasOwnProperty("start") && session.headerRange.hasOwnProperty("end")) {
+    return [session.headerRange.start.column, session.headerRange.end.column]
+  }
+
+  if (!session.sheet || session.sheet == "") {
+    console.warn("HeaderRowDisplay: No sheet selected so finding mode from rows is not possible")
+    return null
+  }
+
+  const r = sheets_lib.GetRows(session)
+  if (r) {
+    return [0, r[0].length]
+  }
+
+  console.warn("HeaderRowDisplay: No rows available when determining number of columns")
+  return null
 }

--- a/lib/importer/src/session.js
+++ b/lib/importer/src/session.js
@@ -1,3 +1,4 @@
+const base26 = require("./base26.js");
 const crypto = require("crypto");
 const sheets_lib = require("./sheets.js");
 const backend = require("./backend");
@@ -67,3 +68,86 @@ var validateUpload = (file) => {
 
   return undefined;
 };
+
+/*
+  * Returns a header row for display, based on the requested mode and the data
+  * currently available in the state.
+  *
+  * The various display modes are:
+  *  - none - return nothing, no display required
+  *  - index - returns the index of the column in base26.
+  *  - source - returns the header names as they are defined in the source file
+  *  - target - returns the header names as they are in the domain object after mapping
+  */
+exports.HeaderRowDisplay = (session, displayMode) => {
+  var mode = displayMode.toLowerCase();
+
+  // User has selected 'none' mode, which means we don't return any headers as
+  // the user does not want to show them.
+  const noneMode = (range) => {
+    return null
+  }
+
+  // Index mode, shows the index as base26 where the values are taken from the range
+  const indexMode = (range) => {
+    if (this.sheet == "") {
+      console.warn("HeaderRowDisplay: No sheet selected so header display mode is 'none'")
+      return null
+    }
+
+    const headers = new Array();
+    for (var i = range[0]; i <= range[1]; i++) {
+      headers.push(base26.toBase26(i + 1))
+    }
+
+    return headers
+  }
+
+  // Using the header values selected by the user, use those instead of column indices.
+  const sourceMode = (range) => {
+    const rows = sheets_lib.GetRows(session, session.headerRange.start.row, session.headerRange.end.row + 1)[0];
+    const headers = new Array();
+
+    for (var i = range[0]; i <= range[1]; i++) {
+      headers.push(rows[i].value)
+    }
+
+    return headers;
+  }
+
+  // Use the header values from the mapped domain object, so the target column headings and the user's data
+  // for that column.
+  const targetMode = (range) => {
+    return noneMode;
+  }
+
+  // Calculate the range, either from the currently selected columns, or from the number
+  // of items in a row (making the assumption that they're even).
+  var range = {};
+  if (session.headerRange.hasOwnProperty("start") && session.headerRange.hasOwnProperty("end")) {
+    range = [session.headerRange.start.column, session.headerRange.end.column]
+  } else {
+    const r = sheets_lib.GetRows(session)
+    if (!r) {
+      console.warn("HeaderRowDisplay: No rows available when determining number of columns")
+      return null
+    } else {
+      range = [0, r[0].length]
+    }
+  }
+
+  switch (mode) {
+    // Index as base26 name
+    case "index":
+      return indexMode(range);
+    // Header names as selected by user
+    case "source":
+      return sourceMode(range);
+    // Header names as the fieldnames for the domain object
+    case "target":
+      return targetMode(range);
+  }
+
+  // If 'none' is specified, or the value provided isn't supported...
+  return noneMode(range);
+}

--- a/lib/importer/src/session.test.js
+++ b/lib/importer/src/session.test.js
@@ -40,7 +40,7 @@ describe("Header Row Display tests", () => {
             basic_session("validation-test.csv")
         ).session;
 
-        s.headerRange = { start: { column: 0 }, end: { column: 1 } }
+        s.headerRange = { start: { row: 0, column: 0 }, end: { row: 0, column: 2 } }
         const headers = session_lib.HeaderRowDisplay(s, "None")
         expect(headers).toBeNull();
     });
@@ -79,7 +79,7 @@ describe("Header Row Display tests", () => {
         ).session;
 
         s.sheet = "Sheet1"
-        s.headerRange = { start: { column: 0 }, end: { column: 2 } }
+        s.headerRange = { start: { row: 0, column: 0 }, end: { row: 0, column: 2 } }
 
         const headers = session_lib.HeaderRowDisplay(s, "index")
         expect(headers).toStrictEqual(["A", "B", "C"])
@@ -95,5 +95,49 @@ describe("Header Row Display tests", () => {
 
         const headers = session_lib.HeaderRowDisplay(s, "index")
         expect(headers).toStrictEqual(["A", "B", "C", "D", "E", "F", "G", "H", "I"])
+    });
+
+    // SOURCE mode
+    test('source mode with no sheet specified', () => {
+        const s = session_lib.CreateSession(
+            basic_config,
+            basic_session("validation-test.csv")
+        ).session;
+
+        console.warn = jest.fn();
+
+        const headers = session_lib.HeaderRowDisplay(s, "source")
+        expect(headers).toBeNull();
+        expect(console.warn.mock.calls[0][0]).toBe('HeaderRowDisplay: No sheet selected so finding mode from rows is not possible');
+    });
+
+    test('source mode with no header range specified', () => {
+        const s = session_lib.CreateSession(
+            basic_config,
+            basic_session("validation-test.csv")
+        ).session;
+
+        console.warn = jest.fn();
+
+
+        s.sheet = "Sheet1";
+
+        const headers = session_lib.HeaderRowDisplay(s, "source")
+        expect(headers).toBeNull();
+        expect(console.warn.mock.calls[0][0]).toBe('HeaderRowDisplay: No header range available for source headers');
+    });
+
+
+    test('source mode with header range available', () => {
+        const s = session_lib.CreateSession(
+            basic_config,
+            basic_session("validation-test.csv")
+        ).session;
+
+        s.sheet = "Sheet1"
+        s.headerRange = { start: { row: 0, column: 1 }, end: { row: 1, column: 3 } }
+
+        const headers = session_lib.HeaderRowDisplay(s, "source")
+        expect(headers).toStrictEqual(["Title", "First name", "Surname"]);
     });
 });

--- a/lib/importer/src/session.test.js
+++ b/lib/importer/src/session.test.js
@@ -1,19 +1,25 @@
-const session = require('./session');
+const session_lib = require('./session');
+
+const basic_config = {
+    fields: [{ name: 'field', type: 'text', required: false }],
+    uploadPath: "../../fixtures",
+};
+
+const basic_session = (filename = "test.xlsx") => {
+    return {
+        file: {
+            mimetype: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            filename: filename
+        }
+    }
+}
 
 describe("Session tests", () => {
 
     test('default session', () => {
-        const response = session.CreateSession(
-            {
-                fields: [{ name: 'field', type: 'text', required: false }],
-                uploadPath: "../../fixtures",
-            },
-            {
-                file: {
-                    mimetype: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-                    filename: "test.xlsx"
-                }
-            }
+        const response = session_lib.CreateSession(
+            basic_config,
+            basic_session()
         );
 
         expect(response.error).toBe(undefined);
@@ -21,5 +27,73 @@ describe("Session tests", () => {
 
         expect(response.session.filename).toEqual('../../fixtures/test.xlsx');
         expect(response.session.fields).toEqual([{ name: "field", type: "text", required: false }]);
+    });
+});
+
+
+describe("Header Row Display tests", () => {
+
+    // NONE mode
+    test('none mode with a header range available', () => {
+        const s = session_lib.CreateSession(
+            basic_config,
+            basic_session("validation-test.csv")
+        ).session;
+
+        s.headerRange = { start: { column: 0 }, end: { column: 1 } }
+        const headers = session_lib.HeaderRowDisplay(s, "None")
+        expect(headers).toBeNull();
+    });
+
+    test('none mode with no header range available', () => {
+        const s = session_lib.CreateSession(
+            basic_config,
+            basic_session("validation-test.csv")
+        ).session;
+
+        console.warn = jest.fn();
+
+        const headers = session_lib.HeaderRowDisplay(s, "None")
+        expect(headers).toBeNull();
+        expect(console.warn.mock.calls[0][0]).toBe('HeaderRowDisplay: No sheet selected so finding mode from rows is not possible');
+    });
+
+    // INDEX mode
+    test('index mode with no sheet specified', () => {
+        const s = session_lib.CreateSession(
+            basic_config,
+            basic_session("validation-test.csv")
+        ).session;
+
+        console.warn = jest.fn();
+
+        const headers = session_lib.HeaderRowDisplay(s, "index")
+        expect(headers).toBeNull();
+        expect(console.warn.mock.calls[0][0]).toBe('HeaderRowDisplay: No sheet selected so finding mode from rows is not possible');
+    });
+
+    test('index mode with header range available', () => {
+        const s = session_lib.CreateSession(
+            basic_config,
+            basic_session("validation-test.csv")
+        ).session;
+
+        s.sheet = "Sheet1"
+        s.headerRange = { start: { column: 0 }, end: { column: 2 } }
+
+        const headers = session_lib.HeaderRowDisplay(s, "index")
+        expect(headers).toStrictEqual(["A", "B", "C"])
+    });
+
+    test('index mode with no header range specified', () => {
+        const s = session_lib.CreateSession(
+            basic_config,
+            basic_session("validation-test.csv")
+        ).session;
+
+        s.sheet = "Sheet1";
+
+        const headers = session_lib.HeaderRowDisplay(s, "index")
+        expect(headers).toStrictEqual(["A", "B", "C", "D", "E", "F", "G", "H", "I"])
     });
 });

--- a/lib/importer/src/sheets.js
+++ b/lib/importer/src/sheets.js
@@ -1,3 +1,4 @@
+const b26 = require('./base26')
 const backend = require("./backend");
 const attributeTypes = require('./attribute-types');
 
@@ -16,17 +17,20 @@ exports.ListSheets = (session) => {
 // it's intended for driving a list of available columns in the header.
 exports.GetHeader = (session) => {
   const headerSample = backend.SessionGetInputSampleRows(session.backendSid, session.headerRange, 1, 0, 0);
-  let untitledCount = 1;
-  return headerSample[0][0].reduce((acc, sample) => {
-    let columnName = sample ? sample.value : (() => {
-      let name = `[Untitled column ${untitledCount}]`;
-      untitledCount += 1;
-      return name;
-    })();
 
-    acc.push(columnName);
-    return acc
-  }, []);
+  const samples = headerSample[0][0];
+  const columns = new Array();
+
+  for (let i = 0; i < samples.length; i++) {
+    if (samples[i]) {
+      columns.push(samples[i].value)
+    } else {
+      const name = b26.toBase26(i + 1);
+      columns.push(name)
+    }
+  }
+
+  return columns
 };
 
 function processMergedCells(wantedColumns, preview) {

--- a/lib/importer/src/sheets.test.js
+++ b/lib/importer/src/sheets.test.js
@@ -22,12 +22,12 @@ test('trailing columns', () => {
     session.sheet = "Sheet1" // It's a CSV, and this is the default sheet name
     session.headerRange = {
         sheet: session.sheet,
-        start: {row: 0, column: 0},
-        end: {row: 0, column: 2},
-      };
+        start: { row: 0, column: 0 },
+        end: { row: 0, column: 2 },
+    };
 
 
     let headers = sheets_lib.GetHeader(session)
     expect(headers.length).toBe(3);
-    expect(headers).toStrictEqual(['A', 'B', '[Untitled column 1]'])
+    expect(headers).toStrictEqual(['A', 'B', 'C'])
 });


### PR DESCRIPTION
Allows tables  to have a table header row (THEAD) that contains values from the following list:

* No headers
* Base26 representation of the column index 
* The selected header row from the source file 
* The target header titles from the domain object (target).

There are obvious contraints on their use (e.g. can't use target mode until mapping done, can't use source until a sheet is selected with a header range).