### PR TITLE
Remove gov logo which re-appeared in a recent dependency update

### DIFF
--- a/lib/importer/assets/docs/articles.html
+++ b/lib/importer/assets/docs/articles.html
@@ -153,7 +153,7 @@
                 </div>
                 <div class="govuk-footer__meta-item">
                     <a href="https://www.register-dynamics.co.uk"
-                        class="govuk-footer__link govuk-footer__copyright-logo rd-logo">
+                        class="govuk-footer__link  rd-logo">
                         &copy; Register Dynamics 2024-2025
                     </a>
                 </div>

--- a/lib/importer/assets/docs/component-sheet-selector.html
+++ b/lib/importer/assets/docs/component-sheet-selector.html
@@ -522,7 +522,7 @@
                 </div>
                 <div class="govuk-footer__meta-item">
                     <a href="https://www.register-dynamics.co.uk"
-                        class="govuk-footer__link govuk-footer__copyright-logo rd-logo">
+                        class="govuk-footer__link rd-logo">
                         &copy; Register Dynamics 2024-2025
                     </a>
                 </div>

--- a/lib/importer/assets/docs/component-table-view.html
+++ b/lib/importer/assets/docs/component-table-view.html
@@ -323,7 +323,7 @@
                 </div>
                 <div class="govuk-footer__meta-item">
                     <a href="https://www.register-dynamics.co.uk"
-                        class="govuk-footer__link govuk-footer__copyright-logo rd-logo">
+                        class="govuk-footer__link rd-logo">
                         &copy; Register Dynamics 2024-2025
                     </a>
                 </div>

--- a/lib/importer/assets/docs/configuration.html
+++ b/lib/importer/assets/docs/configuration.html
@@ -305,7 +305,7 @@
                 </div>
                 <div class="govuk-footer__meta-item">
                     <a href="https://www.register-dynamics.co.uk"
-                        class="govuk-footer__link govuk-footer__copyright-logo rd-logo">
+                        class="govuk-footer__link rd-logo">
                         &copy; Register Dynamics 2024-2025
                     </a>
                 </div>

--- a/lib/importer/assets/docs/docs.css
+++ b/lib/importer/assets/docs/docs.css
@@ -32,11 +32,9 @@
     margin-bottom: 3em;
 }
 
-.rd-service-card .govuk-main-wrapper>[class^="govuk"]:not(
-    [class^="govuk-heading"],
+.rd-service-card .govuk-main-wrapper>[class^="govuk"]:not([class^="govuk-heading"],
     [class^="govuk-panel"],
-    [class^="govuk-grid-column"]
-) {
+    [class^="govuk-grid-column"]) {
     transform: scale(3);
     transform-origin: top left;
 }
@@ -186,43 +184,51 @@ a.sub-navigation-link {
 }
 
 a.sub-navigation-link:hover {
-  text-decoration-thickness: max(3px, .1875rem, .12em);
-  -webkit-text-decoration-skip-ink: none;
-  text-decoration-skip-ink: none;
-  -webkit-text-decoration-skip: none;
-  text-decoration-skip: none;
+    text-decoration-thickness: max(3px, .1875rem, .12em);
+    -webkit-text-decoration-skip-ink: none;
+    text-decoration-skip-ink: none;
+    -webkit-text-decoration-skip: none;
+    text-decoration-skip: none;
 }
 
 a.sub-navigation-link:focus {
-  outline: 3px solid transparent;
-  color: #0b0c0c;
-  background-color: #ffdd00;
-  box-shadow: 0 -2px #ffdd00, 0 4px #0b0c0c;
-  text-decoration: none;
-  -webkit-box-decoration-break: clone;
-  box-decoration-break: clone;
+    outline: 3px solid transparent;
+    color: #0b0c0c;
+    background-color: #ffdd00;
+    box-shadow: 0 -2px #ffdd00, 0 4px #0b0c0c;
+    text-decoration: none;
+    -webkit-box-decoration-break: clone;
+    box-decoration-break: clone;
 }
+
 a.sub-navigation-link:link {
-  color: #1d70b8;
+    color: #1d70b8;
 }
+
 a.sub-navigation-link:visited {
-  color: #1d70b8;
+    color: #1d70b8;
 }
+
 a.sub-navigation-link:hover {
-  color: #004466;
+    color: #004466;
 }
+
 a.sub-navigation-link:active {
-  color: #0b0c0c;
+    color: #0b0c0c;
 }
+
 a.sub-navigation-link:focus {
-  color: #0b0c0c;
+    color: #0b0c0c;
 }
+
 a.sub-navigation-link:not(:hover):not(:active) {
-  text-decoration: none;
+    text-decoration: none;
 }
+
 a.sub-navigation-link:not(:focus):hover {
-  color: #006688;
+    color: #006688;
 }
+
 div#static-header {
     padding-bottom: 1em;
 }

--- a/lib/importer/assets/docs/how-it-works.html
+++ b/lib/importer/assets/docs/how-it-works.html
@@ -171,7 +171,7 @@
                 </div>
                 <div class="govuk-footer__meta-item">
                     <a href="https://www.register-dynamics.co.uk"
-                        class="govuk-footer__link govuk-footer__copyright-logo rd-logo">
+                        class="govuk-footer__link rd-logo">
                         &copy; Register Dynamics 2024-2025
                     </a>
                 </div>

--- a/lib/importer/assets/docs/index.html
+++ b/lib/importer/assets/docs/index.html
@@ -182,7 +182,7 @@
                 </div>
                 <div class="govuk-footer__meta-item">
                     <a href="https://www.register-dynamics.co.uk"
-                        class="govuk-footer__link govuk-footer__copyright-logo rd-logo">
+                        class="govuk-footer__link rd-logo">
                         &copy; Register Dynamics 2024-2025
                     </a>
                 </div>

--- a/lib/importer/assets/docs/pattern-tabular-data.html
+++ b/lib/importer/assets/docs/pattern-tabular-data.html
@@ -532,7 +532,7 @@
                 </div>
                 <div class="govuk-footer__meta-item">
                     <a href="https://www.register-dynamics.co.uk"
-                        class="govuk-footer__link govuk-footer__copyright-logo rd-logo">
+                        class="govuk-footer__link rd-logo">
                         &copy; Register Dynamics 2024-2025
                     </a>
                 </div>

--- a/lib/importer/assets/docs/start.html
+++ b/lib/importer/assets/docs/start.html
@@ -253,7 +253,7 @@
                 </div>
                 <div class="govuk-footer__meta-item">
                     <a href="https://www.register-dynamics.co.uk"
-                        class="govuk-footer__link govuk-footer__copyright-logo rd-logo">
+                        class="govuk-footer__link  rd-logo">
                         &copy; Register Dynamics 2024-2025
                     </a>
                 </div>

--- a/lib/importer/assets/docs/what-it-is.html
+++ b/lib/importer/assets/docs/what-it-is.html
@@ -144,7 +144,7 @@
                 </div>
                 <div class="govuk-footer__meta-item">
                     <a href="https://www.register-dynamics.co.uk"
-                        class="govuk-footer__link govuk-footer__copyright-logo rd-logo">
+                        class="govuk-footer__link rd-logo">
                         &copy; Register Dynamics 2024-2025
                     </a>
                 </div>

--- a/prototypes/basic/app/views/layouts/footer.html
+++ b/prototypes/basic/app/views/layouts/footer.html
@@ -33,7 +33,7 @@
           </div>
           <div class="govuk-footer__meta-item">
               <a href="https://www.register-dynamics.co.uk"
-                  class="govuk-footer__link govuk-footer__copyright-logo rd-logo">
+                  class="govuk-footer__link rd-logo">
                   &copy; Register Dynamics 2024-2025
               </a>
           </div>


### PR DESCRIPTION
Removes the crown logo which made a reappearance after a recent dependency update.  The RD logo is not making an appearance and we need to figure out why, but I thought it was better to get the logo removed after the last incident and come back to our logo.