### PR TITLE
#786: Suggest fields for columns

### DIFF
--- a/lib/importer/src/dudk/backend.js
+++ b/lib/importer/src/dudk/backend.js
@@ -510,6 +510,35 @@ exports.SessionGetSupportedTypes = (sid) => {
   return types.supportedTypes;
 };
 
+// Given guesses as returned by SessionGuessTypes and a list of domain-model
+// fields (with name and type fields), returns the type guesses with each column
+// augmented with a `fields` field - a Map mapping likely field names for this
+// column to an array of possible formats for that field.
+
+exports.SessionSuggestFields = (sid, typeGuesses, domainModelFields) => {
+  let result = [];
+
+  typeGuesses.forEach((colTypeGuess) => {
+    let fieldFormats = new Map(); // Map from field names to likely formats
+    // Examine every field, and check if they have a type that this column might
+    // contain
+    domainModelFields.forEach((field) => {
+      if(colTypeGuess.types.has(field.type)) {
+        // Add this field to the possibilities for the column, using the guessed
+        // formats
+        fieldFormats.set(field.name, colTypeGuess.types.get(field.type));
+      }
+    });
+
+    // Extend the column type guess with the "fields" field
+    let typeGuessesAndFields = Object.assign({}, colTypeGuess);
+    typeGuessesAndFields.fields = fieldFormats;
+    result.push(typeGuessesAndFields);
+  });
+
+  return result;
+};
+
 // Return the unique values in each column in the range. Return no more than
 // maxValues values for any given column. Return format is an array, one entry
 // per column, whose entries have a .values property that's an array of values

--- a/lib/importer/src/dudk/backend.test.js
+++ b/lib/importer/src/dudk/backend.test.js
@@ -561,4 +561,74 @@ test('guessing types', () => {
     {full:true, types:new Map([["text", false]])},
     {full:false, types:new Map([["text", false]])}
   ]);
+
+  const fieldSuggestions = backend.SessionSuggestFields(sid, guesses, [
+    {
+      name: "numberField",
+      required: true,
+      type: "number"
+    },
+    {
+      name: "dateField",
+      required: true,
+      type: "date"
+    },
+    {
+      name: "textField",
+      required: true,
+      type: "text"
+    },
+    { // This one will have no matches
+      name: "postcodeField",
+      required: true,
+      type: "postcode"
+    }
+  ]);
+
+  expect(fieldSuggestions).toMatchObject([
+    // Order is actually irrelevant for all formats lists, so this test over-specifies a bit
+    {full:true, types:new Map([["number", false],["text", false]]),
+     fields: new Map([
+       ["numberField",false],
+       ["textField",false]
+     ])},
+    {full:true, types:new Map([["date", ["ymd"]],["text", false]]),
+     fields: new Map([
+       ["dateField",["ymd"]],
+       ["textField",false]
+     ])},
+    {full:true, types:new Map([["date", ["ydm"]],["text", false]]),
+     fields: new Map([
+       ["dateField",["ydm"]],
+       ["textField",false]
+     ])},
+    {full:true, types:new Map([["date", ["dmy"]],["text", false]]),
+     fields: new Map([
+       ["dateField",["dmy"]],
+       ["textField",false]
+     ])},
+    {full:true, types:new Map([["date", ["mdy"]],["text", false]]),
+     fields: new Map([
+       ["dateField",["mdy"]],
+       ["textField",false]
+     ])},
+    {full:true, types:new Map([["date", ["ymd","ydm"]],["text", false]]),
+     fields: new Map([
+       ["dateField",["ymd","ydm"]],
+       ["textField",false]
+     ])},
+    {full:false, types:new Map([["number", false],["text", false]]),
+     fields: new Map([
+       ["numberField",false],
+       ["textField",false]
+     ])},
+    {full:true, types:new Map([["text", false]]),
+     fields: new Map([
+       ["textField",false]
+     ])},
+    {full:false, types:new Map([["text", false]]),
+     fields: new Map([
+       ["textField",false]
+     ])}
+  ]);
 });


### PR DESCRIPTION
This adds SessionSuggestFields, a utility function in the backend that cross-references type guesses from SessionGuessTypes and a domain model's list of fields, to suggest possible fields (and corresponding formats) for each column.

It exists simply to save frontend logic containing logic to peruse data structures!