### PR TITLE
Used index mode for header chrome in errors

### DIFF
--- a/lib/importer/templates/review.html
+++ b/lib/importer/templates/review.html
@@ -50,7 +50,7 @@
         <h1 class="govuk-heading-l">Review your data</h1>
 
         <!-- Errors reported by processing -->
-        {% set tableHeaders =  importerHeaderRowDisplay(data, "source") %}
+        {% set tableHeaders =  importerHeaderRowDisplay(data, "index") %}
 
         <p class="govuk-body">
             During import there were <strong>{{results.errorCount}}</strong> errors and <strong>{{results.warningCount}}</strong> warnings.

--- a/prototypes/basic/app/views/review.html
+++ b/prototypes/basic/app/views/review.html
@@ -50,7 +50,7 @@
         <h1 class="govuk-heading-l">Review your data</h1>
 
         <!-- Errors reported by processing -->
-        {% set tableHeaders =  importerHeaderRowDisplay(data, "source") %}
+        {% set tableHeaders =  importerHeaderRowDisplay(data, "index") %}
 
         <p class="govuk-body">
             During import there were <strong>{{results.errorCount}}</strong> errors and <strong>{{results.warningCount}}</strong> warnings.


### PR DESCRIPTION
Header row for errors in review should use the index mode rather than the source mode.  This will show the headers as A, B, C etc 