### PR TITLE
Explain that salary is required

### DIFF
--- a/prototypes/basic/app/config.json
+++ b/prototypes/basic/app/config.json
@@ -28,7 +28,7 @@
         },
         {
             "name": "Salary",
-            "required": false,
+            "required": true,
             "type": "number"
         },
         {

--- a/prototypes/basic/app/views/index.html
+++ b/prototypes/basic/app/views/index.html
@@ -41,10 +41,16 @@
           <li>Surname</li>
           <li>Employee number</li>
           <li>Employment start date</li>
-          <li>Salary</li>
+          <li>Salary (required)</li>
           <li>Payment date</li>
         </ul>
       </p>
+    </p>
+
+    <p class="govuk-body">
+      The Salary field is required. If you do not provide a salary in a particular row, an error message will be shown
+      providing context for where the error occurs.  Processing will continue, but the row will not be imported.
+      You can then correct the error and re-upload the file.
     </p>
 
     <p class="govuk-body">


### PR DESCRIPTION
Makes 'Salary' a required field so that errors are viewable in the demonstration.  Adds some context to the homepage explaining that it is required.