### PR TITLE
Clean up errors on each new request

### DIFF
--- a/lib/importer/src/index.js
+++ b/lib/importer/src/index.js
@@ -82,8 +82,8 @@ exports.Initialise = (config, router, prototypeKit) => {
   // remember errors after they have been shown,
   //--------------------------------------------------------------------
   const cleanRequest = (request) => {
-    delete request.session.data['reference_number'];
     delete request.session.data[IMPORTER_ERROR_KEY];
+    delete request.session.data[IMPORTER_ERROR_DATA_KEY];
     delete request.session.data[IMPORTER_ERROR_EXTRA_KEY];
   };
 
@@ -124,18 +124,28 @@ exports.Initialise = (config, router, prototypeKit) => {
     response.redirect(decodeURIComponent(request.query.next));
   };
 
+
   //--------------------------------------------------------------------
-  // Starts the upload process by clearing any lingering error messages
-  // from the session. We can't rely on clearing _all_ of the session so
-  // we are a bit more selective in what is deleted before redirecting
-  // to the next step. This avoids us having to 'clear session data' each
-  // time we run through the process.
+  // Clean any error message from the session. This is used to
+  // ensure that we do not have any lingering error messages from
+  // previous requests.
+  //--------------------------------------------------------------------
+  router.use((request, response, next) => {
+    cleanRequest(request);
+    next();
+  })
+
+  //--------------------------------------------------------------------
+  // Starts the upload process by removing any previous reference number
+  // from the session, and then redirecting to the next URL.
+  //
+  // TODO: Decide if we want to delete the entire session object when we
+  // start a new upload, or just the reference number.
   //--------------------------------------------------------------------
   router.all(
     IMPORTER_ROUTE_MAP.get("importerStartPath"),
     (request, response) => {
-
-      cleanRequest(request);
+      delete request.session.data['reference_number'];
       redirectOnwards(request, response);
     },
   );
@@ -151,8 +161,6 @@ exports.Initialise = (config, router, prototypeKit) => {
     IMPORTER_ROUTE_MAP.get("importerUploadPath"),
     uploader.single("file"),
     (request, response) => {
-      cleanRequest(request);
-
       let createResponse = session_lib.CreateSession(plugin_config, request);
       if (createResponse.error) {
         request.session.data[IMPORTER_ERROR_KEY] = createResponse.error;


### PR DESCRIPTION
We use the session to hold error information to be displayed on the page.  We previously used a function that could be called which would remove any error artifacts from the session before the request was processed.  This was however not applied consistently.

This PR now introduces a middleware which will remove session data from the session at the start of each request.