### PR TITLE
Correctly map errors into presentation structure

### DIFF
--- a/lib/importer/src/dudk/sheets.js
+++ b/lib/importer/src/dudk/sheets.js
@@ -297,20 +297,10 @@ exports.MapData = (sid, sheet, mapping, fields, previewLimit = DEFAULT_PREVIEW_L
   // away but keep the mapping so we can re-run the job later and do something
   // useful with the full results.
 
-  // Get the source headers for the errors/warnings without having to import code from
-  // the plugin.
-  const getSourceHeaders = (rowRange) => {
-    const hrange = backend.SessionGetHeaderRange(sid, rowRange.sheet);
-    const headerRow = exports.GetRows(sid, rowRange.sheet, hrange.start.row, hrange.end.row + 1)[0];
-
-    return new Map( headerRow.row.map((cell, index) => [cell.value, index]) )
-  }
-
   // How do we actually get the source data for the errors/warnings?
-  const sourceHeaders = getSourceHeaders(rowRange);
   const sourceData =   backend.SessionGetInputSampleRows(sid, rowRange, rowRange.end.row - rowRange.start.row + 1)[0];
-  const errors = remapErrorStructure(errorData, sourceData, sourceHeaders);
-  const warnings = remapErrorStructure(warningData, sourceData, sourceHeaders);
+  const errors = remapErrorStructure(errorData, sourceData, rewrittenMapping.attributeMappings, hRange.end.row + 1);
+  const warnings = remapErrorStructure(warningData, sourceData, rewrittenMapping.attributeMappings, hRange.end.row + 1);
 
   // Delete the job results from the backend
   backend.JobDelete(sid, backendJid);
@@ -344,8 +334,18 @@ exports.MapData = (sid, sheet, mapping, fields, previewLimit = DEFAULT_PREVIEW_L
 // This groups results first by error message, highlighting which fields (columns) have that error, and then
 // which rows have that error. This is useful for displaying errors in a table format. Ideally, we want the
 // cell object to contain an indication of whether it has an error or not, so we can highlight it in the table.
-const remapErrorStructure = (errors, row_data, sourceHeaders) => {
+//
+// The default for headerRangeOffset is to account for the translation from row index to array index.
+const remapErrorStructure = (errors, row_data, mappingIndices, headerRangeOffset=1) => {
     const messageMap = new Map();
+
+    const rowHasError = (row) => {
+      if (!row || !Array.isArray(row)) {
+        return false;
+      }
+      return row.some(cell => cell && cell.error);
+    }
+
 
     for (const error of errors) {
         if (!messageMap.has(error.message)) {
@@ -358,42 +358,43 @@ const remapErrorStructure = (errors, row_data, sourceHeaders) => {
             errorObj.fields = new Set();
         }
         if( !errorObj.rows) {
-            errorObj.rows = new Set();
+            errorObj.rows = new Map();
         }
         errorObj.fields.add(error.field);
+        errorObj.context = new Set();
 
-        let realErrorIndex = error.row - 1; // Convert to 0-based index
+        // Convert to 0-based index
+        let realErrorIndex = error.row - headerRangeOffset;
         if (realErrorIndex < 0) {
           realErrorIndex = 0
         }
 
-        if (row_data && Array.isArray(row_data) && error.row <= row_data.length)  {
-            // If row_data is provided, use the value from row_data; otherwise, use the row index
-            let rowValue = row_data[realErrorIndex];
+        if (row_data && Array.isArray(row_data) && realErrorIndex < row_data.length )  {
 
-            // Add previous, current, and next row values if available
-            if (realErrorIndex > 0) {
-                errorObj.rows.add(row_data[realErrorIndex - 1]);
+            let previousRow = structuredClone(row_data[realErrorIndex - 1]);
+            let currentRow = structuredClone(row_data[realErrorIndex]);
+            let nextRow = structuredClone(row_data[realErrorIndex + 1]);
+
+            if (previousRow) {
+              if (!rowHasError(errorObj.rows.get(previousRow.index)?.row)) {
+                errorObj.rows.set(previousRow.index,  previousRow);
+              }
             }
 
-            // We have to lookup in the rowValue the cell which is causing the error
-            // and add the error tag to it.
-            const errorCellIndex = sourceHeaders.get(error.field);
-            if ( rowValue && rowValue.row && errorCellIndex !== undefined && rowValue.row[errorCellIndex]) {
-                // Error cell is at errorCellIndex and so we should flag it as an error
-                rowValue.row[errorCellIndex].error = true; // Mark this cell as having an error
+            // Set the error flag in the correct cell of  the current row
+            const errorCellIndex = mappingIndices[error.field];
+            if (!currentRow.row[errorCellIndex])  {
+              currentRow.row[errorCellIndex] = { value: '   ', error: true };
             } else {
-                // The error cell is not defined in the rowValue, so we create a fake cell
-                // with an error. This is useful for cases where the cell is not present
-                rowValue.row[errorCellIndex] = {index: error.row, error: true, value: ''};
+              currentRow.row[errorCellIndex].error = true;
             }
 
-            errorObj.rows.add(rowValue);
+            errorObj.rows.set(currentRow.index, currentRow);
 
-            if (error.row < row_data.length) {
-              // Add the next row if it exists, ensuring we remove any error flag as this is just context
-              // for the error.
-              errorObj.rows.add(row_data[error.row]);
+            if (nextRow) {
+              if (!rowHasError(errorObj.rows.get(nextRow.index)?.row)) {
+                errorObj.rows.set(nextRow.index, nextRow);
+              }
             }
         }
     }
@@ -402,7 +403,7 @@ const remapErrorStructure = (errors, row_data, sourceHeaders) => {
     return Array.from(messageMap.entries().map(([message, errorObj]) => {
         // Some rows may not have any errors because they are for surrounding context,
         // so we need to filter them out for the meta info
-        const errorRows = Array.from(errorObj.rows).filter(rowObj => rowObj.row.some(element=>element.error) );
+        const errorRows = Array.from(errorObj.rows.values()).filter(rowObj => rowObj.row.some(element=>element && element.error) );
         return {
             message: message,
             meta: {
@@ -410,7 +411,7 @@ const remapErrorStructure = (errors, row_data, sourceHeaders) => {
                 count: errorRows?.length || 0
             },
             fields: Array.from(errorObj.fields),
-            rows: Array.from(errorObj.rows)
+            rows: Array.from(errorObj.rows.values())
         }
     }));
 }

--- a/lib/importer/src/dudk/sheets.test.js
+++ b/lib/importer/src/dudk/sheets.test.js
@@ -126,4 +126,114 @@ describe('remapErrorStructure', () => {
             { message: "Error 1", meta: { count: 0, first: 0}, fields: ["A"], rows: [] }
         ]);
     });
+
+    test('remapping errors - missing fields', () => {
+        const errors =  [
+            { row: 2, field: 'Salary', message: "'Salary' must be supplied" },
+            { row: 3, field: 'Salary', message: "'Salary' must be supplied" },
+            { row: 5, field: 'Salary', message: "'Salary' must be supplied" }
+        ] ;
+        const row_data =
+        [
+            {index: 2, row: [{value: "2"}, {value: "Mr"}, {value: "Odie"}, {value: "Arbuckle"}, {value: "2025-02-01"}, {value: "123" }, {value: "12%"}, {value: "2025-04-01"}]},
+            {index: 3, row: [{value: "1"}, {value: "Mr"}, {value: "Jon"}, {value: "Arbuckle"}, {value: "2025-01-01"}, undefined, undefined, {value: "2025-04-01"}]},
+            {index: 4, row: [{value: "1"}, {value: "Mr"}, {value: "Jon"}, {value: "Arbuckle"}, {value: "2025-01-01"}, undefined, undefined, {value: "2025-04-01"}]},
+            {index: 5, row: [{value: "2"}, {value: "Mr"}, {value: "Odie"}, {value: "Arbuckle"}, {value: "2025-02-01"}, {value: "123"}, {value: "12%"}, {value: "2025-04-01"}]},
+            {index: 6, row: [{value: "1"}, {value: "Mr"}, {value: "Jon"}, {value: "Arbuckle"}, {value: "2025-01-01"}, undefined, undefined, {value: "2025-04-01"}]},
+            {index: 7, row: [{value: "2"}, {value: "Mr"}, {value: "Odie"}, {value: "Arbuckle"}, {value: "2025-02-01"}, {value: "123"}, {value: "12%"}, {value: "2025-04-01"}]}
+        ];
+        const mappingIndices =  {
+            'Employee number': 0,
+            Title: 1,
+            'First name': 2,
+            Surname: 3,
+            'Employment start date': 4,
+            Salary: 5,
+            'Contribution percentage': 6,
+            'Payment date': 7
+        } ;
+        const headerRangeOffset = 1;
+
+        const result = sheets_lib.RemapErrorStructure(errors, row_data, mappingIndices, headerRangeOffset);
+        expect(result).toEqual([
+            {
+                message: "'Salary' must be supplied",
+                fields: ['Salary'],
+                meta: { first: 3, count: 3 },
+                rows: [
+                    // errors in index 3, 5 and 6
+                    { index: 2, row: [{value: "2"}, {value: "Mr"}, {value: "Odie"}, {value: "Arbuckle"}, {value: "2025-02-01"}, {value: "123" }, {value: "12%"}, {value: "2025-04-01"}]},
+                    { index: 3, row: [{ value: "1" }, { value: "Mr" }, { value: "Jon" }, { value: "Arbuckle" }, { value: "2025-01-01" }, { value: "   ", error: true}, undefined, { value: "2025-04-01" }] },
+                    { index: 4, row: [{ value: "1" }, { value: "Mr" }, { value: "Jon" }, { value: "Arbuckle" }, { value: "2025-01-01" }, { value: "   ", error: true}, undefined, { value: "2025-04-01" }] },
+                    { index: 5, row: [{value: "2"}, {value: "Mr"}, {value: "Odie"}, {value: "Arbuckle"}, {value: "2025-02-01"}, {value: "123"}, {value: "12%"}, {value: "2025-04-01"}]},
+                    { index: 6, row: [{ value: "1" }, { value: "Mr" }, { value: "Jon" }, { value: "Arbuckle" }, { value: "2025-01-01" }, { value: "   ", error: true}, undefined, { value: "2025-04-01" }] },
+                    { index: 7, row: [{value: "2"}, {value: "Mr"}, {value: "Odie"}, {value: "Arbuckle"}, {value: "2025-02-01"}, {value: "123"}, {value: "12%"}, {value: "2025-04-01"}]}
+                ]
+            }
+        ]);
+
+    });
+
+    test('remapping errors - multiple errors', () => {
+        const errors =  [
+            { row: 3, field: 'Salary', message: "'Salary' must be supplied" },
+            { row: 4, field: 'Salary', message: 'This is not a valid number' },
+            { row: 5, field: 'Salary', message: "'Salary' must be supplied" },
+            { row: 6, field: 'Salary', message: 'This is not a valid number' },
+            { row: 7, field: 'Salary', message: "'Salary' must be supplied" },
+            { row: 8, field: 'Salary', message: "'Salary' must be supplied" }
+        ] ;
+        const row_data = [
+            { index: 4, row: [
+                {value: "Kris"}, {value: "1-1-24"}, {value: "1:00"}, {value: "5.5"}, {value: "Pink"}, {value: "Splotches"}, undefined
+            ]},
+            { index: 5, row: [
+                {value: "Alex"}, {value: "2-4-24"}, {value: "4:34"}, {value: "6"}, {value: "Beige"}, {value: "N/A"}, {value: "My fave <3"}
+            ]},
+            { index: 6, row: [
+                {value: "Drew"}, {value: "3-5-24"}, {value: "15:05"}, {value: "6.5"}, {value: "Brown"}, {value: "Blob on top"}, undefined
+            ]},
+            { index: 7, row: [
+                {value: "Jamie"}, {value: "2-3-24"}, {value: "6:01"}, {value: "8.4"}, {value: "Pink"}, undefined, {value: "Evil!!"}
+            ]},
+            { index: 8, row: [
+                {value: "Emm"}, {value: "1-5-24"}, {value: "9:55"}, {value: "4.9"}, {value: "Maroon"}, {value: "Yes"}, undefined
+            ]},
+            { index: 9, row: [
+                {value: "Elm"}, {value: "4-5-24"}, {value: "10:43"}, {value: "5.6"}, {value: "Black"}, {value: "Stripese"}, undefined
+            ]},
+        ];
+        const mappingIndices =  { 'First name': 0, Salary: 6 } ;
+        const headerRangeOffset = 3 ;
+
+        const result = sheets_lib.RemapErrorStructure(errors, row_data, mappingIndices, headerRangeOffset);
+        expect(result).toEqual([
+            {
+                message: "'Salary' must be supplied",
+                meta: { first: 4, count: 4 },
+                fields: [ 'Salary' ],
+                rows:[
+                    { index: 4, row: [ {value: "Kris"}, {value: "1-1-24"}, {value: "1:00"}, {value: "5.5"}, {value: "Pink"}, {value: "Splotches"}, {value: "   ", error: true} ]},
+                    { index: 5, row: [ {value: "Alex"}, {value: "2-4-24"}, {value: "4:34"}, {value: "6"}, {value: "Beige"}, {value: "N/A"}, {value: "My fave <3"} ]},
+                    { index: 6, row: [ {value: "Drew"}, {value: "3-5-24"}, {value: "15:05"}, {value: "6.5"}, {value: "Brown"}, {value: "Blob on top"}, {value: "   ", error: true}]},
+                    { index: 7, row: [ {value: "Jamie"}, {value: "2-3-24"}, {value: "6:01"}, {value: "8.4"}, {value: "Pink"}, undefined, {value: "Evil!!"} ]},
+                    { index: 8, row: [ {value: "Emm"}, {value: "1-5-24"}, {value: "9:55"}, {value: "4.9"}, {value: "Maroon"}, {value: "Yes"}, {value: "   ", error: true} ]},
+                    { index: 9, row: [ {value: "Elm"}, {value: "4-5-24"}, {value: "10:43"}, {value: "5.6"}, {value: "Black"}, {value: "Stripese"}, {value: "   ", error: true}]},
+                ]
+            },
+            {
+                message: 'This is not a valid number',
+                meta: { first: 5, count: 2 },
+                fields: [ 'Salary' ],
+                rows: [
+                    { index: 4, row: [ {value: "Kris"}, {value: "1-1-24"}, {value: "1:00"}, {value: "5.5"}, {value: "Pink"}, {value: "Splotches"}, undefined ]},
+                    { index: 5, row: [ {value: "Alex"}, {value: "2-4-24"}, {value: "4:34"}, {value: "6"}, {value: "Beige"}, {value: "N/A"}, {value: "My fave <3", error: true} ]},
+                    { index: 6, row: [ {value: "Drew"}, {value: "3-5-24"}, {value: "15:05"}, {value: "6.5"}, {value: "Brown"}, {value: "Blob on top"}, undefined]},
+                    { index: 7, row: [ {value: "Jamie"}, {value: "2-3-24"}, {value: "6:01"}, {value: "8.4"}, {value: "Pink"}, undefined, {value: "Evil!!", error: true} ]},
+                    { index: 8, row: [ {value: "Emm"}, {value: "1-5-24"}, {value: "9:55"}, {value: "4.9"}, {value: "Maroon"}, {value: "Yes"}, undefined ]},
+                ]
+            }
+        ]);
+
+    });
 });

--- a/lib/importer/src/dudk/sheets.test.js
+++ b/lib/importer/src/dudk/sheets.test.js
@@ -2,7 +2,7 @@
 const backend = require('./backend');
 const sheets_lib = require('./sheets');
 
-const SourceHeaders = {A: 0, B: 1, C: 2};
+const RewrittenMapping = {A: 0, B: 1, C: 2};
 
 test('trailing columns', () => {
 
@@ -35,7 +35,7 @@ describe('remapErrorStructure', () => {
             {index: 1, row:[{value:"0", error:true},{value:"1",error:true}]},
             {index: 2, row: [{value:"2", error:true}, {value:"3", error:true}]}
         ];
-        const result = sheets_lib.RemapErrorStructure(errors, row_data, SourceHeaders);
+        const result = sheets_lib.RemapErrorStructure(errors, row_data, RewrittenMapping);
         expect(result).toEqual([
             {
                 message: "Error 1",
@@ -67,7 +67,7 @@ describe('remapErrorStructure', () => {
             {index: 1, row: [{value:"0", error: true},{value:"1"}]},
             {index: 2, row: [{value:"2", error: true}, {value:"3"}]}
         ];
-        const result = sheets_lib.RemapErrorStructure(errors, row_data, SourceHeaders);
+        const result = sheets_lib.RemapErrorStructure(errors, row_data, RewrittenMapping);
         expect(result).toEqual([
             {
                 message: "Error 1",
@@ -90,7 +90,7 @@ describe('remapErrorStructure', () => {
             {index: 1, row: [{value:"0", error: true},{value:"1"}]},
             {index: 2, row: [{value:"2"}, {value:"3"}]}
         ];
-        const result = sheets_lib.RemapErrorStructure(errors, row_data, SourceHeaders, 1);
+        const result = sheets_lib.RemapErrorStructure(errors, row_data, RewrittenMapping, 1);
 
         // For row 1: only 0, 1
         // For row 3: 2, 3
@@ -121,7 +121,7 @@ describe('remapErrorStructure', () => {
             {index: 1, row: [{value:"0"},{value:"1"}]},
             {index: 2, row: [{value:"2"}, {value:"3"}]}
         ];
-        const result = sheets_lib.RemapErrorStructure(errors, row_data, SourceHeaders);
+        const result = sheets_lib.RemapErrorStructure(errors, row_data, RewrittenMapping);
         expect(result).toEqual([
             { message: "Error 1", meta: { count: 0, first: 0}, fields: ["A"], rows: [] }
         ]);

--- a/lib/importer/src/dudk/sheets.test.js
+++ b/lib/importer/src/dudk/sheets.test.js
@@ -1,10 +1,8 @@
-const fs = require('fs');
-const path = require('path');
 
 const backend = require('./backend');
 const sheets_lib = require('./sheets');
 
-const SourceHeaders = new Map([["A", 0], ["B", 1], ["C", 2]]);
+const SourceHeaders = {A: 0, B: 1, C: 2};
 
 test('trailing columns', () => {
 
@@ -70,7 +68,6 @@ describe('remapErrorStructure', () => {
             {index: 2, row: [{value:"2", error: true}, {value:"3"}]}
         ];
         const result = sheets_lib.RemapErrorStructure(errors, row_data, SourceHeaders);
-
         expect(result).toEqual([
             {
                 message: "Error 1",
@@ -93,7 +90,8 @@ describe('remapErrorStructure', () => {
             {index: 1, row: [{value:"0", error: true},{value:"1"}]},
             {index: 2, row: [{value:"2"}, {value:"3"}]}
         ];
-        const result = sheets_lib.RemapErrorStructure(errors, row_data, SourceHeaders);
+        const result = sheets_lib.RemapErrorStructure(errors, row_data, SourceHeaders, 1);
+
         // For row 1: only 0, 1
         // For row 3: 2, 3
         expect(result).toEqual([

--- a/lib/importer/src/dudk/sheets.test.js
+++ b/lib/importer/src/dudk/sheets.test.js
@@ -90,7 +90,7 @@ describe('remapErrorStructure', () => {
             {index: 1, row: [{value:"0", error: true},{value:"1"}]},
             {index: 2, row: [{value:"2"}, {value:"3"}]}
         ];
-        const result = sheets_lib.RemapErrorStructure(errors, row_data, RewrittenMapping, 1);
+        const result = sheets_lib.RemapErrorStructure(errors, row_data, RewrittenMapping);
 
         // For row 1: only 0, 1
         // For row 3: 2, 3

--- a/lib/importer/templates/review.html
+++ b/lib/importer/templates/review.html
@@ -61,7 +61,7 @@
             {% for error in results.errors %}
                 <div class="govuk-form-group govuk-form-group--error">
                     <h2 class="govuk-heading-m validation-error-message">{{error.message}}</h2>
-                    <p class="govuk-body">This error occurs {{error.meta.count | count_string}} in your data. The first time at row {{ error.meta.first}}:</p>
+                    <p class="govuk-body">This error occurs {{error.meta.count | count_string}} in your data. The first time is at row {{ error.meta.first}}:</p>
 
                     {{ tableView( {
                             caption: false,
@@ -81,7 +81,7 @@
             {% for warning in results.warnings %}
                 <div class="govuk-form-group govuk-form-group--error">
                     <h2 class="govuk-heading-m validation-error-message">{{warning.message}}</h2>
-                    <p class="govuk-body">This warning occurs {{warning.meta.count | count_string}} in your data. The first time at row {{ warning.meta.first}}:</p>
+                    <p class="govuk-body">This warning occurs {{warning.meta.count | count_string}} in your data. The first time is at row {{ warning.meta.first}}:</p>
 
 
                     {{ tableView( {


### PR DESCRIPTION
The previous version of this function was incorrectly locating the cells with errors in based on the source headers (e.g. titles in sheet) instead of the mapping.  This meant that we were not identifying the errors in each row, unless the mapping was identical to the source headers.

This change ensures that the errors are shown and are grouped correctly along with local context (previous and following rows).

Updating of errors into include field name will be added in a separate PR