### PR TITLE
Highlight error rows where no cell error

### DIFF
--- a/lib/importer/nunjucks/importer/macros/table_view.njk
+++ b/lib/importer/nunjucks/importer/macros/table_view.njk
@@ -27,7 +27,7 @@ Renders a table view using the provided parameters to determine what is being sh
         {% endif %}
         <tbody>
             {% for rowObj in params.rows %}
-            <tr class="govuk-table__row {% if importerRowHasHeader(rowObj) %}
+            <tr class="govuk-table__row {% if rowObj.error %}
             validation-error{%endif%}">
 
 

--- a/lib/importer/src/functions.js
+++ b/lib/importer/src/functions.js
@@ -244,11 +244,6 @@ const parseNumberFromString = (s) => {
     return parseInt(parsed[0])
 }
 
-const importerRowHasHeader = (rowObj) => {
-    return rowObj.row.some( (element) => element && element.error )
-}
-
-
 module.exports = {
     importerError,
     importerErrorMappingData,
@@ -259,7 +254,6 @@ module.exports = {
     importerGetTableCaption,
     importerMappedData,
     importerHeaderRowDisplay,
-    importerRowHasHeader,
     data_sum,
     data_avg
 }


### PR DESCRIPTION
Where a row error (warning typically) occurs, highlight the row even if now cells have errors.  Allows us to remove an now unsed but exported function in addition to simplifying the table view macro.