### PR TITLE
Don't include footer row in example values during mapping

### DIFF
--- a/lib/importer/src/dudk/sheets.js
+++ b/lib/importer/src/dudk/sheets.js
@@ -211,6 +211,12 @@ exports.GetColumnValues = (sid, sheet, columnIndex, cellWidth = 30, count = 10) 
   // Limit to just the column we want
   dataRange.start.column += columnIndex;
   dataRange.end.column = dataRange.start.column;
+
+  // The range passed to SessionGetInputValues is inclusive, and therefore
+  // we end up with the first row of the selected footer. To avoid this
+  // we will decrement the end.row to ensure we don't pull too make values.
+  dataRange.end.row = dataRange.end.row - 1
+
   let values = backend.SessionGetInputValues(
     sid,
     dataRange,


### PR DESCRIPTION
Currently during mapping we identify the data range to select some examples from, but the call that is made expects an inclusive range, and we want an exclusive one. Due to the lack of options wrt range types we instead just decrement the range we want to retrieve.

We may want to consider having different range types to avoid having to add/subtract one based on requirements, and perhaps make iteration and calculations easier