### PR TITLE
Configuration for auto-sheet selection when only one

### DIFF
--- a/lib/importer/src/config.js
+++ b/lib/importer/src/config.js
@@ -34,7 +34,7 @@ exports.PluginConfig = class {
   // Should we auto-select a sheet when there is only one sheet?
   //    manual - No, always select a sheet even if there is only one.
   //    automatic - Yes, always use the single sheet when there is only one.
-    this.sheetSelection = config.sheetSelection || "automatic";
+    this.sheetSelection = config.sheetSelection || "manual";
 
     // If the config fields are in the old format (just names) then move them to
     // the new structure with default values of text for the type, and not required.

--- a/lib/importer/src/config.js
+++ b/lib/importer/src/config.js
@@ -31,6 +31,11 @@ exports.PluginConfig = class {
     this.uploadPath = config.uploadPath;
     this.uploadPathDefault = false;
 
+  // Should we auto-select a sheet when there is only one sheet?
+  //    manual - No, always select a sheet even if there is only one.
+  //    automatic - Yes, always use the single sheet when there is only one.
+    this.sheetSelection = config.sheetSelection || "automatic";
+
     // If the config fields are in the old format (just names) then move them to
     // the new structure with default values of text for the type, and not required.
     if (this.fields.find(Boolean)) {
@@ -77,10 +82,18 @@ exports.PluginConfig = class {
     }
   };
 
+  setSheetSelection = (mode) => {
+      if (!["manual", "automatic"].includes(mode)) {
+        throw (`'${mode}' is not a valid sheet selection mode`)
+      }
+      this.sheetSelection = mode
+    }
+
   as_object = () => {
     return {
       uploadPath: this.uploadPathDefault ? TEMP_DIRECTORY_LABEL : this.uploadPath,
-      fields: this.fields
+      fields: this.fields,
+      sheetSelection: this.sheetSelection
     }
   }
 
@@ -95,6 +108,7 @@ exports.PluginConfig = class {
     let current = fse.readJsonSync(configFilePath);
 
     current.fields = this.fields;
+    current.sheetSelection = this.sheetSelection
 
     fse.writeJsonSync(configFilePath, current);
   };

--- a/lib/importer/src/config.test.js
+++ b/lib/importer/src/config.test.js
@@ -36,6 +36,8 @@ describe("Configuration tests", () => {
                 expect(original.uploadPath).not.toBeNull()
                 expect(updated.uploadPath).not.toBeNull()
                 expect(c.uploadPath).not.toBeNull()
+                expect(updated.sheetSelection).not.toBeNull()
+                expect(updated.sheetSelection).toStrictEqual("automatic")
             }
         );
 
@@ -127,6 +129,69 @@ describe("Configuration tests", () => {
             (original, updated) => {
                 expect(original.uploadPath).toBe("/tmp")
                 expect(updated.uploadPath).toBe("/tmp")
+            }
+        );
+
+        mock_files.restore();
+    });
+
+test('manual sheet selection', () => {
+        mock_files({
+            './fields/app/config.json': '{"fields": [{"name":"A"}, {"name": "B"}, {"name": "C"}]}',
+        })
+
+        withCurrent(
+            "./fields",
+            new cfg.PluginConfig(),
+            (c) => {
+                c.setSheetSelection("manual")
+                c.persistConfig()
+            },
+            (original, updated) => {
+                expect(updated.sheetSelection).toStrictEqual("manual")
+            }
+        );
+
+        mock_files.restore();
+    });
+
+    test('default sheet selection', () => {
+        mock_files({
+            './fields/app/config.json': '{"fields": [{"name":"A"}, {"name": "B"}, {"name": "C"}]}',
+        })
+
+        withCurrent(
+            "./fields",
+            new cfg.PluginConfig(),
+            (c) => {
+                c.persistConfig()
+            },
+            (original, updated) => {
+                expect(updated.sheetSelection).toStrictEqual("automatic")
+            }
+        );
+
+        mock_files.restore();
+    });
+
+
+    test('invalid sheet selection', () => {
+        mock_files({
+            './fields/app/config.json': '{"fields": [{"name":"A"}, {"name": "B"}, {"name": "C"}]}',
+        })
+
+        withCurrent(
+            "./fields",
+            new cfg.PluginConfig(),
+            (c) => {
+                expect(() => {
+                    c.setSheetSelection("invalid")
+                }
+                ).toThrow("'invalid' is not a valid sheet selection mode")
+                c.persistConfig()
+            },
+            (original, updated) => {
+                expect(updated.sheetSelection).toStrictEqual("automatic")
             }
         );
 

--- a/lib/importer/src/config.test.js
+++ b/lib/importer/src/config.test.js
@@ -37,7 +37,7 @@ describe("Configuration tests", () => {
                 expect(updated.uploadPath).not.toBeNull()
                 expect(c.uploadPath).not.toBeNull()
                 expect(updated.sheetSelection).not.toBeNull()
-                expect(updated.sheetSelection).toStrictEqual("automatic")
+                expect(updated.sheetSelection).toStrictEqual("manual")
             }
         );
 
@@ -167,7 +167,7 @@ test('manual sheet selection', () => {
                 c.persistConfig()
             },
             (original, updated) => {
-                expect(updated.sheetSelection).toStrictEqual("automatic")
+                expect(updated.sheetSelection).toStrictEqual("manual")
             }
         );
 
@@ -191,7 +191,7 @@ test('manual sheet selection', () => {
                 c.persistConfig()
             },
             (original, updated) => {
-                expect(updated.sheetSelection).toStrictEqual("automatic")
+                expect(updated.sheetSelection).toStrictEqual("manual")
             }
         );
 

--- a/lib/importer/src/index.js
+++ b/lib/importer/src/index.js
@@ -100,7 +100,11 @@ exports.Initialise = (config, router, prototypeKit) => {
 
     prototypeKit.views.addFunction(
       k,
-      (next) => {
+      (next, other = null) => {
+        if (next && other) {
+          return `${v}?next=${encodeURIComponent(next)}&other=${encodeURIComponent(other)}`;
+        }
+
         return `${v}?next=${encodeURIComponent(next)}`;
       },
       {},
@@ -171,7 +175,16 @@ exports.Initialise = (config, router, prototypeKit) => {
 
       if (session.sheets.length == 1) {
         session.sheet = session.sheets[0];
+
+        // When there is only a single sheet, and if the prototype is configured to
+        // automatically progress, then this will do so if the 'other' url is
+        // specified.
+        if (plugin_config.sheetSelection.toLowerCase() == "automatic" && "other" in request.query) {
+          const otherPage = decodeURIComponent(request.query.other)
+          if (otherPage) { request.query.next = request.query.other }
+        }
       }
+
       // Ensure the session is persisted. Currently in session, eventually another way
       request.session.data[IMPORTER_SESSION_KEY] = session;
       redirectOnwards(request, response);

--- a/lib/importer/src/index.js
+++ b/lib/importer/src/index.js
@@ -405,6 +405,7 @@ exports.Initialise = (config, router, prototypeKit) => {
           config: {
             fields: plugin_config.fields
           },
+          sheetMode: plugin_config.sheetSelection || "manual",
           collectUsageData: usageRecorder.enabled,
         }
 
@@ -445,6 +446,12 @@ exports.Initialise = (config, router, prototypeKit) => {
           usageRecorder.setPermission(false)
         }
 
+        const sheetMode = request.body.sheetMode || "manual"
+        if (["manual", "automatic"].includes(sheetMode.toLowerCase())) {
+          plugin_config.sheetSelection = sheetMode.toLowerCase()
+        } else {
+          plugin_config.sheetSelection = "manual"
+        }
 
         setTimeout(function () {
           plugin_config.persistConfig()

--- a/lib/importer/templates/upload.html
+++ b/lib/importer/templates/upload.html
@@ -12,7 +12,7 @@
     <div class="govuk-grid-column-two-thirds">
         <h1 class="govuk-heading-l">Upload your data</h1>
 
-        <form action="{{importerUploadPath('/select_sheet')}}" method="POST" enctype="multipart/form-data">
+        <form action="{{importerUploadPath('/select_sheet', '/select_header_row')}}" method="POST" enctype="multipart/form-data">
             <div>
                 {{ govukFileUpload({
                 id: "file-upload",

--- a/lib/importer/templates/upload.html
+++ b/lib/importer/templates/upload.html
@@ -12,6 +12,7 @@
     <div class="govuk-grid-column-two-thirds">
         <h1 class="govuk-heading-l">Upload your data</h1>
 
+        <!-- Upload to select sheet, but in automatic mode, will go to header selection instead -->
         <form action="{{importerUploadPath('/select_sheet', '/select_header_row')}}" method="POST" enctype="multipart/form-data">
             <div>
                 {{ govukFileUpload({

--- a/lib/importer/views/plugin_config.html
+++ b/lib/importer/views/plugin_config.html
@@ -97,6 +97,48 @@
 
     <div class="govuk-grid-column-full govuk-!-padding-top-6" >
         <h2 class="govuk-heading-l"></h2>
+ <div class="govuk-form-group">
+    <fieldset class="govuk-fieldset">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+      <h1 class="govuk-fieldset__heading">
+        Auto sheet selection
+      </h1>
+    </legend>
+
+    <div class="govuk-radios" data-module="govuk-radios">
+      <p class="govuk-body">
+      When a user uploads a spreadsheet and there is only a single sheet,
+      the plugin can either automatically select the first sheet
+      or allow the user to choose a specific sheet.
+
+      The default is to allow the user to choose the sheet,
+      but by selecting 'automatic' here the single sheet
+      will always be used without user intevention skipping the sheet
+      selection screen.
+      </p>
+
+      <div id="type-hint" class="govuk-hint">
+        Choose auto-sheet selection mode
+      </div>
+
+      <div class="govuk-radios__item">
+          <input class="govuk-radios__input" id="field-sheet-manual" name="sheetMode" type="radio" value="manual" {% if sheetMode == "manual" %}checked{% endif %}>
+          <label class="govuk-label govuk-radios__label" for="field-sheet-manual">
+            Manual
+          </label>
+        </div>
+        <div class="govuk-radios__item">
+          <input class="govuk-radios__input" id="field-sheet-automatic" name="sheetMode" type="radio" value="automatic" {% if sheetMode == "automatic" %}checked{% endif %}>
+          <label class="govuk-label govuk-radios__label" for="field-sheet-automatic">
+            Automatic
+          </label>
+        </div>
+      </div>
+    </div> <!-- fieldset -->
+</div> <!-- form-group -->
+
+<div class="govuk-grid-column-full govuk-!-padding-top-6" >
+<h2 class="govuk-heading-l"></h2>
 
 <div class="govuk-form-group">
   <fieldset class="govuk-fieldset">

--- a/prototypes/basic/app/config.json
+++ b/prototypes/basic/app/config.json
@@ -1,5 +1,6 @@
 {
     "serviceName": "Upload monthly pension return",
+    "sheetSelection": "automatic",
     "fields": [
         {
             "name": "Title",

--- a/prototypes/basic/app/config.json
+++ b/prototypes/basic/app/config.json
@@ -1,6 +1,5 @@
 {
     "serviceName": "Upload monthly pension return",
-    "sheetSelection": "automatic",
     "fields": [
         {
             "name": "Title",

--- a/prototypes/basic/app/views/upload.html
+++ b/prototypes/basic/app/views/upload.html
@@ -56,7 +56,8 @@
           </ul>
         </p>
 
-        <form action="{{importerUploadPath('/select_sheet')}}" method="POST" enctype="multipart/form-data">
+        <!-- Upload to select sheet, but in automatic mode, will go to header selection instead -->
+        <form action="{{importerUploadPath('/select_sheet', '/select_header_row')}}" method="POST" enctype="multipart/form-data">
             <div>
                 {{ govukFileUpload({
                 id: "file-upload",


### PR DESCRIPTION
In some cases files are uploaded that contain only a single sheet.

It seems wasteful to show the user the single sheet and expect them to continue, so we will provide a config option that allows owners of the prototype to decide whether to always show the sheet selection screen, or to skip it when there is only one sheet.  

As the sheet selection may still be valuable as a visual indicator that the user has uploaded the correct sheet, we will allow the configutation options to be "manual" or "automatic" with 'manual' always showing the select sheet screen, and 'automatic' skipping it when it can.

The default, should the implementor never set a value, is manual to avoid an unexpected change of behaviour after updating the library.

Resolves #197 
