### PR TITLE
Update install instructions in docs

### DIFF
--- a/lib/importer/assets/docs/start.html
+++ b/lib/importer/assets/docs/start.html
@@ -128,7 +128,7 @@
               <p>
                   Open up your preferred command line, which you previously used to create a GOV.UK Prototype, and type the following:
               </p>
-              <pre>npm install 'https://gitpkg.vercel.app/register-dynamics/data-import/lib/importer?main'</pre>
+              <pre>npm install --save  @register-dynamics/importer@latest</pre>
               <p>
                 After running this command new routes will automatically be added
                 to your prototype’s <code>app/routes.js</code> file.


### PR DESCRIPTION
Update the documentation to show how users can install the plugin using the usual npm process.

Of course, if your default registry has been modified you'll need to specify it, but if users are using custom registries the likelihood is that they know how to specify which to use on a case-by-case basis.