### PR TITLE
Fix server error page

### DIFF
--- a/lib/importer/nunjucks/views/error-handling/server-error.njk
+++ b/lib/importer/nunjucks/views/error-handling/server-error.njk
@@ -1,5 +1,7 @@
 {% extends "layouts/main.html" %}
 
+{% from "govuk/components/footer/macro.njk" import govukFooter %}
+
 {% block pageTitle %}
   Error {% if serviceName %}– {{ serviceName }}{% endif %} – GOV.UK Prototype Kit
 {% endblock %}


### PR DESCRIPTION
Template was missing the govukFooter include, and so was failing to show the server error when it happened.