### PR TITLE
Provide basic docs on error messages

### DIFF
--- a/lib/importer/templates/review.html
+++ b/lib/importer/templates/review.html
@@ -24,6 +24,26 @@
         {% if results.errors.length > 0 %}
             <h2 class="govuk-heading-m">Errors</h2>
             {% for errorObject in results.errors %}
+
+                {#
+                    This error object is generated when there was a problem processing the
+                    data. The error object contains a type, meta information and the rows that
+                    caused the error with some surrounding rows for context.
+
+                    The meta information field contains:
+                        count - the number of times this error occurred
+                        first - the first row number where this error occurred
+
+                    The type field contains information about the error that occurred, including
+                    the variant of error, possible values for which are:
+                        * FieldRequired
+                        * IncorrectType
+                        * MonthUnrecognised
+                        * MonthOutOfRange
+                        * DayOutOfRange
+                        * DayWrongType
+                #}
+
                 {% set error = errorObject.type %}
                 <div class="govuk-form-group govuk-form-group--error">
                     <h2 class="govuk-heading-m validation-error-message">
@@ -62,6 +82,30 @@
         {% if results.warnings.length > 0 %}
             <h2 class="govuk-heading-m">Warnings</h2>
             {% for warningObject in results.warnings %}
+
+                {#
+                    This warning object is generated when there was a problem processing the
+                    data but it did not stop processing. These warnings are to alert the user to
+                    potential issues with the data.
+
+                    The error object contains a type, meta information and the rows that
+                    caused the error with some surrounding rows for context.
+
+                    The meta information field contains:
+                        count - the number of times this error occurred
+                        first - the first row number where this error occurred
+
+                    The type field contains information about the error that occurred, including
+                    the variant of error, possible values for which are:
+                        * EmptyRow
+                        * ShortRow
+                        * UnknownDateFormat
+                        * UnrecognisableDateFormat
+                        * DateGuessing20thCentury
+                        * DateGuessing21stCentury
+                #}
+
+
                 {% set warning = warningObject.type %}
 
                 <div class="govuk-form-group govuk-form-group--error">

--- a/lib/importer/views/plugin_config.html
+++ b/lib/importer/views/plugin_config.html
@@ -19,7 +19,6 @@
         {{ message }}
       </div>
     </div>
-
   {% endif %}
 
 
@@ -177,7 +176,18 @@
     </p>
   </fieldset>
 </div>
-    </div>
+</div>
+
+    <div class="govuk-grid-column-full govuk-!-padding-top-6" >
+      <h2 class="govuk-heading-l">Error messages</h2>
+
+      <p class="govuk-body">
+        To update the error messages shown when there is a problem with the uploaded data,
+        you can edit the messages in the review template, found in '<code>./views/review.html</code>'.
+        This template checks the type of error and shows a relevant message. You can modify these messages
+        to suit your needs.
+      </p>
+  </div>
 
 
     <div class="govuk-grid-column-full govuk-!-padding-top-6" >

--- a/lib/importer/views/plugin_config.html
+++ b/lib/importer/views/plugin_config.html
@@ -183,7 +183,7 @@
 
       <p class="govuk-body">
         To update the error messages shown when there is a problem with the uploaded data,
-        you can edit the messages in the review template, found in '<code>./views/review.html</code>'.
+        you can edit the messages in the review template, found in '<code>./app/views/review.html</code>'.
         This template checks the type of error and shows a relevant message. You can modify these messages
         to suit your needs.
       </p>

--- a/prototypes/basic/app/views/review.html
+++ b/prototypes/basic/app/views/review.html
@@ -59,6 +59,27 @@
         {% if results.errors.length > 0 %}
             <h2 class="govuk-heading-m">Errors</h2>
             {% for errorObject in results.errors %}
+
+                {#
+                    This error object is generated when there was a problem processing the
+                    data. The error object contains a type, meta information and the rows that
+                    caused the error with some surrounding rows for context.
+
+                    The meta information field contains:
+                        count - the number of times this error occurred
+                        first - the first row number where this error occurred
+
+                    The type field contains information about the error that occurred, including
+                    the variant of error, possible values for which are:
+                        * FieldRequired
+                        * IncorrectType
+                        * MonthUnrecognised
+                        * MonthOutOfRange
+                        * DayOutOfRange
+                        * DayWrongType
+                #}
+
+
                 {% set error = errorObject.type %}
                 <div class="govuk-form-group govuk-form-group--error">
                      <h2 class="govuk-heading-m validation-error-message">
@@ -97,8 +118,29 @@
         {% if results.warnings.length > 0 %}
             <h2 class="govuk-heading-m">Warnings</h2>
             {% for warningObject in results.warnings %}
-                {% set warning = warningObject.type %}
+                {#
+                    This warning object is generated when there was a problem processing the
+                    data but it did not stop processing. These warnings are to alert the user to
+                    potential issues with the data.
 
+                    The error object contains a type, meta information and the rows that
+                    caused the error with some surrounding rows for context.
+
+                    The meta information field contains:
+                        count - the number of times this error occurred
+                        first - the first row number where this error occurred
+
+                    The type field contains information about the error that occurred, including
+                    the variant of error, possible values for which are:
+                        * EmptyRow
+                        * ShortRow
+                        * UnknownDateFormat
+                        * UnrecognisableDateFormat
+                        * DateGuessing20thCentury
+                        * DateGuessing21stCentury
+                #}
+
+                {% set warning = warningObject.type %}
                 <div class="govuk-form-group govuk-form-group--error">
                     <h2 class="govuk-heading-m validation-error-message">
                         {% switch warning.variant %}


### PR DESCRIPTION
Comments added to the review page in the demo (and the source template) explain how to use the errors returned from the backend.

In addition, the config page has a short paragraph in case the user thought they were edited there.  This points them back to the review template.